### PR TITLE
move elixir to pro so need tree-sitter-lang-pro package and use older tree-sitter-elixir

### DIFF
--- a/lang/release
+++ b/lang/release
@@ -64,7 +64,7 @@ fi
 # Language-specific options
 GEN_OCAML_OPTIONS=""
 case "$lang" in
-  apex)
+  apex|elixir)
     GEN_OCAML_OPTIONS="--package tree-sitter-lang-pro"
     ;;
   *)


### PR DESCRIPTION
test plan:
./release elixir and check the semgrep-elixir now has
adjusted dune files


### Security

- [x] Change has no security implications (otherwise, ping the security team)