### PR TITLE
chore: Update tree-sitter-rust (3/n)

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-rust/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-rust/grammar.js
@@ -84,15 +84,9 @@ module.exports = grammar(standard_grammar, {
       ')'
     ),
 
-    meta_arguments: ($, previous) => seq(
-      '(',
-      sepBy(',', choice(
-	$.ellipsis,
-	$.meta_item,
-        $._literal
-      )),
-      optional(','),
-      ')'
+    _non_special_token: ($, previous) => choice(
+      previous,
+      $.ellipsis,
     ),
 
     // TODO: have to use 13 instead of PREC.field because the Rust grammar

--- a/lang/semgrep-grammars/src/semgrep-rust/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-rust/test/corpus/semgrep.txt
@@ -222,24 +222,22 @@ Ellipsis for attribute arguments
 
 (source_file
       (attribute_item
-        (meta_item
+        (attribute
           (identifier)
-          (meta_arguments
+          (token_tree
             (ellipsis))))
       (attribute_item
-        (meta_item
+        (attribute
           (identifier)
-          (meta_arguments
-            (meta_item
-              (identifier))
+          (token_tree
+            (identifier)
             (ellipsis))))
       (attribute_item
-        (meta_item
+        (attribute
           (identifier)
-          (meta_arguments
+          (token_tree
             (ellipsis)
-            (meta_item
-              (identifier))
+            (identifier)
             (ellipsis)))))
 
 ================================================================================


### PR DESCRIPTION
Among other things, this pulls in some significant changes how macros are handled. There were two major changes, months apart, and I wanted to pull them both in at once, so this is a fairly major jump.

I also ran in to a weird issue parsing the Semgrep ellipsis that was sorted out in a later commit, so I pulled in some more commits after the macro changes as well.

Test plan: Automated tests, plus pulled this in to Semgrep and verified that tests pass there.

### Security

- [ ] Change has no security implications (otherwise, ping the security team)
