### PR TITLE
chore: named ellipses in java

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-java/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-java/grammar.js
@@ -51,11 +51,13 @@ module.exports = grammar(base_grammar, {
     primary_expression: ($, previous) => choice(
       previous,
       $.semgrep_ellipsis,
+      $.semgrep_named_ellipsis
     ),
 
     statement: ($, previous) => choice(
       previous,
       $.semgrep_ellipsis,
+      $.semgrep_named_ellipsis
     ),
 
     formal_parameter: ($, previous) => choice(
@@ -66,7 +68,8 @@ module.exports = grammar(base_grammar, {
 
     _class_body_declaration: ($, previous) => choice(
       previous,
-      $.semgrep_ellipsis
+      $.semgrep_ellipsis,
+      $.semgrep_named_ellipsis
     ),
 
     partials: $ => choice(

--- a/lang/semgrep-grammars/src/semgrep-java/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-java/grammar.js
@@ -45,6 +45,8 @@ module.exports = grammar(base_grammar, {
     ),
 
     semgrep_ellipsis: $ => '...',
+    semgrep_named_ellipsis: $ => /\$\.\.\.[A-Z_][A-Z_0-9]*/,
+
 
     primary_expression: ($, previous) => choice(
       previous,
@@ -59,6 +61,7 @@ module.exports = grammar(base_grammar, {
     formal_parameter: ($, previous) => choice(
       previous,
       $.semgrep_ellipsis,
+      $.semgrep_named_ellipsis
     ),
 
     _class_body_declaration: ($, previous) => choice(
@@ -70,7 +73,7 @@ module.exports = grammar(base_grammar, {
        $.partial_method,
     ),
 
-    // partial of method_declaration 
+    // partial of method_declaration
     partial_method: $ => seq(
       optional($.modifiers),
       $._method_header

--- a/lang/semgrep-grammars/src/semgrep-java/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-java/test/corpus/semgrep.txt
@@ -183,3 +183,26 @@ class $X {
             (variable_declarator
               (identifier)
               (identifier))))))))
+
+================================================================================
+Metavariable ellipsis parameter
+================================================================================
+
+class $X {
+  void $ASDF($...PARAMS) {
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(program
+  (class_declaration
+    (identifier)
+    (class_body
+      (method_declaration
+        (void_type)
+        (identifier)
+        (formal_parameters
+          (formal_parameter
+            (semgrep_named_ellipsis)))
+        (block)))))

--- a/lang/semgrep-grammars/src/semgrep-java/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-java/test/corpus/semgrep.txt
@@ -19,16 +19,16 @@ bar();
 
 --------------------------------------------------------------------------------
 
-  (program
-    (expression_statement
-      (method_invocation
-        (identifier)
-        (argument_list)))
-    (semgrep_ellipsis)
-    (expression_statement
-      (method_invocation
-        (identifier)
-        (argument_list))))
+(program
+  (expression_statement
+    (method_invocation
+      (identifier)
+      (argument_list)))
+  (semgrep_ellipsis)
+  (expression_statement
+    (method_invocation
+      (identifier)
+      (argument_list))))
 
 ================================================================================
 Top level public constructor
@@ -72,15 +72,16 @@ public record $R(...) {
 }
 
 --------------------------------------------------------------------------------
+
 (program
-      (record_declaration
-        (modifiers)
-        (identifier)
-        (formal_parameters
-          (formal_parameter
-            (semgrep_ellipsis)))
-        (class_body
-          (semgrep_ellipsis))))
+  (record_declaration
+    (modifiers)
+    (identifier)
+    (formal_parameters
+      (formal_parameter
+        (semgrep_ellipsis)))
+    (class_body
+      (semgrep_ellipsis))))
 
 ================================================================================
 Method header
@@ -91,14 +92,14 @@ public int foo(...)
 --------------------------------------------------------------------------------
 
 (program
-      (partials
-        (partial_method
-          (modifiers)
-          (integral_type)
-          (identifier)
-          (formal_parameters
-            (formal_parameter
-              (semgrep_ellipsis))))))
+  (partials
+    (partial_method
+      (modifiers)
+      (integral_type)
+      (identifier)
+      (formal_parameters
+        (formal_parameter
+          (semgrep_ellipsis))))))
 
 ================================================================================
 Constructor body ellipsis
@@ -185,7 +186,7 @@ class $X {
               (identifier))))))))
 
 ================================================================================
-Metavariable ellipsis parameter
+Named ellipsis parameter
 ================================================================================
 
 class $X {
@@ -206,3 +207,38 @@ class $X {
           (formal_parameter
             (semgrep_named_ellipsis)))
         (block)))))
+
+================================================================================
+Named ellipsis statements
+================================================================================
+
+foo();
+$...STMTS
+bar();
+
+--------------------------------------------------------------------------------
+
+(program
+  (expression_statement
+    (method_invocation
+      (identifier)
+      (argument_list)))
+  (semgrep_named_ellipsis)
+  (expression_statement
+    (method_invocation
+      (identifier)
+      (argument_list))))
+
+================================================================================
+Named ellipsis expression
+================================================================================
+
+1 + $...NAMED;
+
+--------------------------------------------------------------------------------
+
+(program
+  (expression_statement
+    (binary_expression
+      (decimal_integer_literal)
+      (semgrep_named_ellipsis))))


### PR DESCRIPTION
As title.

In particular, this PR allows named ellipses to be used as statements, expressions, and parameters.

### Security

- [X] Change has no security implications (otherwise, ping the security team)
