### PR TITLE
elixir allows ellipsis in keyword/pair positions

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-elixir/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-elixir/grammar.js
@@ -19,7 +19,7 @@ module.exports = grammar(base_grammar, {
   rules: {
     // No need for _SEMGREP_EXPRESSION hack here, because Elixir allows
     // toplevel expressions.
-      
+
     // Metavariables
     identifier: ($, previous) => {
       return choice(
@@ -33,12 +33,28 @@ module.exports = grammar(base_grammar, {
     // Ellipsis
     // No need for extensions to _expressions for ellipsis because
     // Elixir already uses "..." as valid identifiers
-      
+    //
+    // However, we do need to override the "pair" rule which is used
+    // for keyword parameters, arguments, and map items. Otherwise,
+    // ellipsis won't work in places where Elixir expects
+    // keyword/pairs, such as
+    //   foo(some_arg: 0, ...)
+    //   %{some_item: 0, ...}
+    // Also note that now there is ambiguity whether foo(...) is an
+    // identity or pair, we set the pair rule to have a lower
+    // precedence
+    pair: ($, previous) => {
+      return prec(-1, choice(
+        previous,
+        '...',
+      ));
+    },
+
     _expression: ($, previous) => choice(
       ...previous.members,
       $.deep_ellipsis,
     ),
-      
+
     // The actual ellipsis rules
     deep_ellipsis: $ => seq(
             '<...', $._expression, '...>'

--- a/lang/semgrep-grammars/src/semgrep-elixir/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-elixir/test/corpus/semgrep.txt
@@ -18,7 +18,7 @@ Ellipsis in calls
 =====================================
 
 def foo do
-  bar(1, ..., 2)
+  bar(1, ..., 2, ..., three: 3, ..., four: 4, ...)
 end
 
 ---
@@ -26,7 +26,13 @@ end
 (source (call (identifier) (arguments (identifier))
    (do_block
 	(call (identifier)
-	      (arguments (integer) (identifier) (integer))))))
+	      (arguments (integer) (identifier) (integer)
+              (identifier)
+              (keywords
+                (pair (keyword) (integer))
+                (pair)
+                (pair (keyword) (integer))
+                (pair)))))))
 
 =====================================
 Deep Ellipsis


### PR DESCRIPTION
Elixir already has ellipsis, but it expects them where identifiers are expected.

But Semgrep also wants to allow ellipsis in other places. This PR allows ellipsis
where keyword/pairs are expected.

Such as function calls `foo(kwd_arg1: 0, ...)` or map items `%{item1: 0, ...}`.

Previously, these cases won't parse.

Tested with `make test`.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
