### PR TITLE
elixir allows metavariables as keywords

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-elixir/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-elixir/grammar.js
@@ -49,16 +49,22 @@ module.exports = grammar(base_grammar, {
     // keyword/pairs, such as
     //   foo(some_arg: 0, ...)
     //   %{some_item: 0, ...}
-    // Also note that now there is ambiguity whether foo(...) is an
-    // identity or pair, we set the pair rule to have a lower
-    // precedence
     pair: ($, previous) => {
-      return prec(-1, choice(
+      return choice(
         previous,
         $.semgrep_ellipsis,
-      ));
+      );
     },
 
+    // Note that because of the pair rule above, now there is
+    // ambiguity whether the ellipsis in foo(...) is an
+    // ellipsis for positional or keyword arguments. If ... matches
+    // with the identity rule, it will be considered a positional
+    // argument. If ... matches with semgrep_ellipsis, it will be
+    // part of parsing the pair rule, which means its a keyword
+    // argument.  In practice, this doesn't matter because either
+    // way, they will become ParamEllipsis in the Generic AST
+    // anyway.
     semgrep_ellipsis: $ => prec(-1, '...'),
 
     _expression: ($, previous) => choice(

--- a/lang/semgrep-grammars/src/semgrep-elixir/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-elixir/grammar.js
@@ -28,6 +28,15 @@ module.exports = grammar(base_grammar, {
       );
     },
 
+    _keyword: ($, previous) => {
+	return choice(
+	    ...previous.members,
+	    $.metavariable_keyword
+      );
+    },
+
+    metavariable_keyword: $ => seq($._semgrep_metavariable, /:\s/),
+
     _semgrep_metavariable: $ => token(/\$[A-Z_][A-Z_0-9]*/),
 
     // Ellipsis
@@ -46,9 +55,11 @@ module.exports = grammar(base_grammar, {
     pair: ($, previous) => {
       return prec(-1, choice(
         previous,
-        '...',
+        $.semgrep_ellipsis,
       ));
     },
+
+    semgrep_ellipsis: $ => prec(-1, '...'),
 
     _expression: ($, previous) => choice(
       ...previous.members,

--- a/lang/semgrep-grammars/src/semgrep-elixir/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-elixir/test/corpus/semgrep.txt
@@ -14,6 +14,22 @@ end
 	      (do_block (call (identifier) (arguments (integer) (integer))))))
 
 =====================================
+Metavariables as key value pairs
+=====================================
+
+%{$KEY: $VALUE}
+
+---
+
+(source
+  (map
+    (map_content
+      (keywords
+        (pair
+          (metavariable_keyword)
+          (identifier))))))
+
+=====================================
 Ellipsis in calls
 =====================================
 
@@ -30,9 +46,9 @@ end
               (identifier)
               (keywords
                 (pair (keyword) (integer))
-                (pair)
+                (pair (semgrep_ellipsis))
                 (pair (keyword) (integer))
-                (pair)))))))
+                (pair (semgrep_ellipsis))))))))
 
 =====================================
 Deep Ellipsis


### PR DESCRIPTION
Previously, keywords (as in keyword/value pairs) didn't allow metavariables, so cases like 
```elixir
  foo($KEYWORD: $VALUE)
  %{$KEYWORD: $VALUE}
```
would fail to parse.

This PR adds support for that.

Also made ellipsis its own rule, as previously suggested at https://github.com/semgrep/ocaml-tree-sitter-semgrep/pull/466.

Tested with make test and added a test.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
