### PR TITLE
OCaml: allow to parse signatures at the toplevel too

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-ocaml/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-ocaml/grammar.js
@@ -10,6 +10,10 @@ module.exports = grammar(base_grammar, {
   name: 'ocaml',
 
   conflicts: ($, previous) => previous.concat([
+    // those conflicts are because of the $._signature in compilation_unit
+    [$._structure_item, $._signature_item],
+    [$._structure, $._signature],
+    [$._module_type, $._simple_module_expression],
   ]),
 
   /*
@@ -17,6 +21,15 @@ module.exports = grammar(base_grammar, {
      if they're not already part of the base grammar.
   */
   rules: {
+    // We should use _signature when parsing .mli and _structure
+    // when parsing .ml but it's tedious in tree-sitter and ocaml-tree-sitter
+    // to have multiple entry points in the grammar, so simpler
+    // to merge both grammars and allow both structures and signatures.
+    compilation_unit: ($, previous) =>
+       choice(
+         previous,
+         $._signature
+       )
   /*
     semgrep_ellipsis: $ => '...',
 

--- a/lang/semgrep-grammars/src/semgrep-ocaml/test/corpus/signatures.txt
+++ b/lang/semgrep-grammars/src/semgrep-ocaml/test/corpus/signatures.txt
@@ -1,0 +1,36 @@
+===========================
+Basic sig
+===========================
+
+val foo: int -> bool
+
+---
+
+(compilation_unit
+      (value_specification
+        (value_name)
+        (function_type
+          (type_constructor_path
+            (type_constructor))
+          (type_constructor_path
+            (type_constructor)))))
+
+===========================
+Object types
+===========================
+
+val foo: < Network.t > -> bool
+
+---
+
+(compilation_unit
+      (value_specification
+        (value_name)
+        (function_type
+          (object_type
+            (type_constructor_path
+              (extended_module_path
+                (module_name))
+              (type_constructor)))
+          (type_constructor_path
+            (type_constructor)))))


### PR DESCRIPTION
This will allow to parse .mli using tree-sitter-ocaml. Right now
the .mli generate parse errors with tree-sitter-ocaml, so we default
back to menhir to parse those .mli (which has some special
code to use different grammar entry points depending whether
we parse a .mli or .ml), but menhir does not handle some
of the latest features of OCaml, so many .mli in the semgrep
codebase actually don't parse (especially the one using
capabilities which are object types).

test plan:
unit test included
cd lang
./test-lang ocaml


### Security

- [x] Change has no security implications (otherwise, ping the security team)