### PR TITLE
Update to less recent tree-sitter-ocaml

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-ocaml/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-ocaml/grammar.js
@@ -12,8 +12,11 @@ module.exports = grammar(base_grammar, {
   conflicts: ($, previous) => previous.concat([
     // those conflicts are because of the $._signature in compilation_unit
     [$._structure_item, $._signature_item],
+    [$._structure_item_ext, $._signature_item_ext],
     [$._structure, $._signature],
-    [$._module_type, $._simple_module_expression],
+    [$.include_module, $.include_module_type],
+    [$.parenthesized_module_type, $.parenthesized_module_expression],
+    [$.functor_type, $.functor],
   ]),
 
   /*


### PR DESCRIPTION
The last time we updated Parse_ocaml_tree_sitter.ml
was with a tree-sitter-ocaml of 2021 ... so there are lots
of changes so let's update by steps, like brandon did for C++.

test plan:
./test-lang ocaml


### Security

- [ ] Change has no security implications (otherwise, ping the security team)