### PR TITLE
update cpp

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-cpp/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-cpp/grammar.js
@@ -41,10 +41,13 @@ module.exports = grammar(base_grammar, {
         $.semgrep_metavar
       ),
 
-    parenthesized_expression: ($, previous) => seq(
+    parenthesized_expression: ($, previous) => choice(
+      previous,
+      seq(
       '(',
-      choice($._expression, $.comma_expression, $.semgrep_typed_metavar),
+      choice($.semgrep_typed_metavar),
       ')',
+      )
     ),
 
     // Metavariables


### PR DESCRIPTION
This PR updates `ocaml-tree-sitter-semgrep` with the most recent `tree-sitter-cpp`, which includes my fix https://github.com/tree-sitter/tree-sitter-cpp/pull/239 which should fix a [grammar error we are currently experiencing](https://linear.app/semgrep/issue/PA-3190/regression-assignments-in-c-conditions-are-not-parsed-correctly).

### Security

- [X] Change has no security implications (otherwise, ping the security team)
