### PR TITLE
elixir allow metavariables as atoms

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-elixir/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-elixir/grammar.js
@@ -29,13 +29,22 @@ module.exports = grammar(base_grammar, {
     },
 
     _keyword: ($, previous) => {
-	return choice(
-	    ...previous.members,
-	    $.metavariable_keyword
+      return choice(
+        ...previous.members,
+        $.metavariable_keyword
       );
     },
 
     metavariable_keyword: $ => seq($._semgrep_metavariable, /:\s/),
+
+    _atom: ($, previous) => {
+      return choice(
+        ...previous.members,
+        $.metavariable_atom
+      );
+    },
+
+    metavariable_atom: $ => seq(":", $._semgrep_metavariable),
 
     _semgrep_metavariable: $ => token(/\$[A-Z_][A-Z_0-9]*/),
 

--- a/lang/semgrep-grammars/src/semgrep-elixir/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-elixir/test/corpus/semgrep.txt
@@ -30,6 +30,17 @@ Metavariables as key value pairs
           (identifier))))))
 
 =====================================
+Metavariables as atoms
+=====================================
+
+:$FOO
+
+---
+
+(source
+  (metavariable_atom))
+
+=====================================
 Ellipsis in calls
 =====================================
 


### PR DESCRIPTION
Elixir has atoms that are pretty much identifiers that start with a colon, e.g. `:foo`.

Metavars can match expressions, but not atoms
* `$ATOM` matches `:foo`
* `:$ATOM` doesn't parse

This PR allows metavars as atoms so `:$ATOM` matches `:foo`.
 
Also fixed some indentation in some previous code.

Test plan: added test in https://github.com/semgrep/semgrep-proprietary/pull/1274

### Security

- [x] Change has no security implications (otherwise, ping the security team)
