### PR TITLE
Update tree-sitter-dockerfile

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-dockerfile/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-dockerfile/grammar.js
@@ -71,7 +71,9 @@ module.exports = grammar(base_grammar, {
           "key",
           choice(
             $.semgrep_metavariable,
-            alias(/[-a-zA-Z0-9\._]+/, $.unquoted_string)
+            alias(/[-a-zA-Z0-9\._]+/, $.unquoted_string),
+            $.double_quoted_string,
+            $.single_quoted_string
           )
         ),
         token.immediate("="),


### PR DESCRIPTION
Uses the latest tree-sitter-dockerfile from the official repo, main branch.

test plan:
```
cd lang
./test-lang dockerfile
```
I pushed the generated code successfully to https://github.com/semgrep/semgrep-dockerfile with `./release dockerfile`.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
