### PR TITLE
chore(js/ts): allow ellipses to occur in jsx elements

### DIFF
--- a/lang/semgrep-grammars/src/Makefile.common
+++ b/lang/semgrep-grammars/src/Makefile.common
@@ -42,7 +42,7 @@ test:
 	# messages when compiling 'parser.c'.
 	set -e; \
 	for dir in $$(find . | grep 'grammar.js$$' | xargs -L1 dirname); do \
-	  echo "Test $$(pwd)"; \
+	  echo "Test $$(pwd)/$$dir"; \
 	  (cd "$$dir"; \
            show_log() { echo "..."; tail -n 1000 test.log; }; \
            if tree-sitter test > test.log 2>&1; then \

--- a/lang/semgrep-grammars/src/semgrep-typescript/common/semgrep-ext.js
+++ b/lang/semgrep-grammars/src/semgrep-typescript/common/semgrep-ext.js
@@ -28,6 +28,7 @@ module.exports = {
     */
 
     semgrep_ellipsis: $ => '...',
+    semgrep_metavar_ellipsis: $ => /\$\.\.\.[A-Z_][A-Z_0-9]*/,
 
     /* In the expression context, there are LR(1) conflicts with spread and
      * rest. I (nmote) don't think that these are true ambiguities, but just in
@@ -38,6 +39,12 @@ module.exports = {
     primary_expression: ($, previous) => choice(
       previous,
       $.semgrep_expression_ellipsis,
+    ),
+
+    _jsx_attribute: ($, previous) => choice(
+      previous,
+      $.semgrep_ellipsis,
+      $.semgrep_metavar_ellipsis
     ),
 
     // TODO Remove this when we update tree-sitter-typescript past

--- a/lang/semgrep-grammars/src/semgrep-typescript/tsx/corpus/semgrep-ext.txt
+++ b/lang/semgrep-grammars/src/semgrep-typescript/tsx/corpus/semgrep-ext.txt
@@ -1,0 +1,49 @@
+==================================
+JSX with ellipsis
+==================================
+
+<Switch .../>
+
+---
+
+(program
+  (expression_statement
+    (jsx_self_closing_element
+      (identifier)
+      (semgrep_ellipsis))))
+
+==================================
+JSX with ellipsis and other props
+==================================
+
+<Switch a="b" ... foo={bar}/>
+
+---
+
+(program
+  (expression_statement
+    (jsx_self_closing_element
+      (identifier)
+      (jsx_attribute
+        (property_identifier)
+        (string
+          (string_fragment)))
+      (semgrep_ellipsis)
+      (jsx_attribute
+        (property_identifier)
+        (jsx_expression
+          (identifier))))))
+
+==================================
+JSX with metavariable ellipsis
+==================================
+
+<Switch $...PROPS/>
+
+---
+
+(program
+  (expression_statement
+    (jsx_self_closing_element
+      (identifier)
+      (semgrep_metavar_ellipsis))))


### PR DESCRIPTION
As title

This PR also fixes the Makefile to also include the name of the dialect that it is dealing with. Previously it only printed the PWD.

### Security

- [X] Change has no security implications (otherwise, ping the security team)
