### PR TITLE
Move-on-Aptos: Support More Declarations and Partial Signatures

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-move-on-aptos/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-move-on-aptos/grammar.js
@@ -15,6 +15,7 @@ module.exports = grammar(base_grammar, {
   conflicts: ($, previous) => previous.concat([
     [$.typed_metavariable, $.name_access_chain],
     [$.term, $.declaration],
+    [$._module_path, $.spec_block_target]
   ]),
 
   precedences: $ => [
@@ -37,26 +38,26 @@ module.exports = grammar(base_grammar, {
     typed_metavariable: $ => seq('(', $.identifier, ':', $.type, ')'),
 
     // Alternate "entry point". Allows parsing a standalone expression.
-    semgrep_expression: $ => seq('__SEMGREP_EXPRESSION', choice(
+    semgrep_expression: $ => choice(
       $._expr,
       $.let_expr,
-    )),
+    ),
 
     // Alternate "entry point". Allows parsing a standalone list of sequence items (statements).
-    semgrep_statement: $ => seq('__SEMGREP_STATEMENT', repeat1(choice(
+    semgrep_statement: $ => repeat1(choice(
       $._sequence_item,
       $.declaration,
-    ))),
+    )),
 
     // Alternate "entry point". Allows parsing partial declarations (signatures).
-    semgrep_partial: $ => seq('__SEMGREP_PARTIAL', seq(
+    semgrep_partial: $ => seq(
       optional($.attributes),
       repeat($.module_member_modifier),
       choice(
         $._function_signature,
         $._struct_signature,
       )
-    )),
+    ),
 
     // Extend the source_file rule to allow semgrep constructs
     source_file: ($, previous) => choice(

--- a/lang/semgrep-grammars/src/semgrep-move-on-aptos/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-move-on-aptos/grammar.js
@@ -19,6 +19,7 @@ module.exports = grammar(base_grammar, {
 
   precedences: $ => [
     [$._sequence_item, $.declaration],
+    [$._script_use_decl, $._script_constant_decl, $._script_func_decl, $._script_spec_block],
   ],
 
   /*
@@ -70,6 +71,13 @@ module.exports = grammar(base_grammar, {
       previous,
       $.ellipsis,
     ),
+
+    // Script members
+    // We cannot mimic the `declaration` trick here, as the script members are strictly ordered.
+    _script_use_decl: ($, previous) => choice(previous, $.ellipsis),
+    _script_constant_decl: ($, previous) => choice(previous, $.ellipsis),
+    _script_func_decl: ($, previous) => choice(previous, $.ellipsis),
+    _script_spec_block: ($, previous) => choice(previous, $.ellipsis),
 
     // Spec block members
     _spec_block_member: ($, previous) => choice(

--- a/lang/semgrep-grammars/src/semgrep-move-on-aptos/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-move-on-aptos/grammar.js
@@ -79,6 +79,12 @@ module.exports = grammar(base_grammar, {
     _script_func_decl: ($, previous) => choice(previous, $.ellipsis),
     _script_spec_block: ($, previous) => choice(previous, $.ellipsis),
 
+    // Address block members
+    _address_member: ($, previous) => choice(
+      previous,
+      $.ellipsis,
+    ),
+
     // Spec block members
     _spec_block_member: ($, previous) => choice(
       previous,

--- a/lang/semgrep-grammars/src/semgrep-move-on-aptos/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-move-on-aptos/grammar.js
@@ -126,6 +126,13 @@ module.exports = grammar(base_grammar, {
       $.ellipsis,
     ),
 
+    // attribute value
+    // (e.g. `#[attr(key = ...)]`)
+    _attribute_val: ($, previous) => choice(
+      previous,
+      $.ellipsis,
+    ),
+
     // use member
     // (e.g. `use module_ident::...;`, `use module_ident::{..., item_ident}`)
     _use_member: ($, previous) => choice(

--- a/lang/semgrep-grammars/src/semgrep-move-on-aptos/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-move-on-aptos/grammar.js
@@ -18,10 +18,10 @@ module.exports = grammar(base_grammar, {
     [$._module_path, $.spec_block_target]
   ]),
 
-  precedences: $ => [
+  precedences: ($, previous) => previous.concat([
     [$._sequence_item, $.declaration],
     [$._script_use_decl, $._script_constant_decl, $._script_func_decl, $._script_spec_block],
-  ],
+  ]),
 
   /*
      Support for semgrep ellipsis ('...') and metavariables ('$FOO'),

--- a/lang/semgrep-grammars/src/semgrep-move-on-aptos/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-move-on-aptos/grammar.js
@@ -140,12 +140,18 @@ module.exports = grammar(base_grammar, {
       $.ellipsis,
     ),
 
+    // term
+    term: ($, previous) => choice(
+      ...previous.members,
+      $.ellipsis,
+      $.deep_ellipsis,
+    ),
+
     // expression 
     _expr: ($, previous) => choice(
       ...previous.members,
       $.ellipsis,
       $.deep_ellipsis,
-      $.field_access_ellipsis_expr,
     ),
 
     // unary expression
@@ -155,6 +161,11 @@ module.exports = grammar(base_grammar, {
       prec(UNARY_PREC, $.deep_ellipsis),
       prec(UNARY_PREC, $.field_access_ellipsis_expr),
       $.typed_metavariable,
+    ),
+
+    _dot_or_index_chain: ($, previous) => choice(
+      ...previous.members,
+      $.field_access_ellipsis_expr,
     ),
 
     // function parameter

--- a/lang/semgrep-grammars/src/semgrep-move-on-aptos/test/corpus/partials_and_decls.txt
+++ b/lang/semgrep-grammars/src/semgrep-move-on-aptos/test/corpus/partials_and_decls.txt
@@ -118,3 +118,34 @@ public native struct $STRUCT has ...
     (abilities
       (ability
         (ellipsis)))))
+
+=======================
+Function Attributes
+=======================
+
+#[attr(key = ...), attr2 = ..., attr3(...), ...]
+fun $FUN (...)
+
+---
+
+(source_file
+  (semgrep_partial
+    (attributes
+      (attribute
+        (identifier)
+        (attribute
+          (identifier)
+          (ellipsis)))
+      (attribute
+        (identifier)
+        (ellipsis))
+      (attribute
+        (identifier)
+        (attribute
+          (ellipsis)))
+      (attribute
+        (ellipsis)))
+    (identifier)
+    (parameters
+      (parameter
+        (ellipsis)))))

--- a/lang/semgrep-grammars/src/semgrep-move-on-aptos/test/corpus/partials_and_decls.txt
+++ b/lang/semgrep-grammars/src/semgrep-move-on-aptos/test/corpus/partials_and_decls.txt
@@ -1,0 +1,124 @@
+=======================
+Function in Statement
+=======================
+
+__SEMGREP_STATEMENT
+fun $TEST (...) : ... { ... }
+
+---
+
+(source_file
+  (semgrep_statement
+    (declaration
+      (function_decl
+        (identifier)
+        (parameters
+          (parameter
+            (ellipsis)))
+        (type
+          (ellipsis))
+        (block
+          (ellipsis))))))
+
+=======================
+Declarations
+=======================
+
+__SEMGREP_STATEMENT
+use 0xabcd::ff;
+struct $STRUCT has ... { ... }
+const $CONST : ... = $FOO(...);
+...
+fun hello (...) {
+  let XXX = $STRUCT { ... };
+  ...
+}
+
+---
+
+(source_file
+  (semgrep_statement
+    (declaration
+      (use_decl
+        (module_ident
+          (numerical_addr
+            (number))
+          (identifier))))
+    (declaration
+      (struct_decl
+        (identifier)
+        (abilities
+          (ability
+            (ellipsis)))
+        (body
+          (field_annot
+            (ellipsis)))))
+      (declaration
+        (constant_decl
+          (identifier)
+          (type
+            (ellipsis))
+          (call_expr
+            (name_access_chain
+              (identifier))
+            (call_args
+              (ellipsis)))))
+    (ellipsis)
+    (declaration
+      (function_decl
+        (identifier)
+        (parameters
+          (parameter
+            (ellipsis)))
+        (block
+          (let_expr
+            (bind_list
+              (var_name
+                (identifier)))
+            (pack_expr
+              (name_access_chain
+                (identifier))
+              (expr_field
+                (ellipsis))))
+          (ellipsis))))))
+
+=======================
+Function Signature
+=======================
+
+__SEMGREP_PARTIAL
+#[test]
+public(friend) fun $FUNC (...)
+
+---
+
+(source_file
+  (semgrep_partial
+    (attributes
+      (attribute
+        (identifier)))
+    (module_member_modifier
+      (visibility))
+    (identifier)
+    (parameters
+      (parameter
+        (ellipsis)))))
+
+=======================
+Struct Signature
+=======================
+
+__SEMGREP_PARTIAL
+public native struct $STRUCT has ...
+
+---
+
+(source_file
+  (semgrep_partial
+    (module_member_modifier
+      (visibility))
+    (module_member_modifier)
+    (identifier)
+    (abilities
+      (ability
+        (ellipsis)))))

--- a/lang/semgrep-grammars/src/semgrep-move-on-aptos/test/corpus/partials_and_decls.txt
+++ b/lang/semgrep-grammars/src/semgrep-move-on-aptos/test/corpus/partials_and_decls.txt
@@ -2,7 +2,6 @@
 Function in Statement
 =======================
 
-__SEMGREP_STATEMENT
 fun $TEST (...) : ... { ... }
 
 ---
@@ -24,7 +23,6 @@ fun $TEST (...) : ... { ... }
 Declarations
 =======================
 
-__SEMGREP_STATEMENT
 use 0xabcd::ff;
 struct $STRUCT has ... { ... }
 const $CONST : ... = $FOO(...);
@@ -86,7 +84,6 @@ fun hello (...) {
 Function Signature
 =======================
 
-__SEMGREP_PARTIAL
 #[test]
 public(friend) fun $FUNC (...)
 
@@ -108,7 +105,6 @@ public(friend) fun $FUNC (...)
 Struct Signature
 =======================
 
-__SEMGREP_PARTIAL
 public native struct $STRUCT has ...
 
 ---

--- a/lang/semgrep-grammars/src/semgrep-move-on-aptos/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-move-on-aptos/test/corpus/semgrep.txt
@@ -2,7 +2,6 @@
 Semgrep Ellipsis
 ====================
 
-__SEMGREP_EXPRESSION
 ...
 
 ---
@@ -15,7 +14,6 @@ __SEMGREP_EXPRESSION
 Semgrep Metavariables
 ========================
 
-__SEMGREP_EXPRESSION
 call(..., $VAR)
 
 ---
@@ -35,7 +33,6 @@ call(..., $VAR)
 Semgrep Statement
 ====
 
-__SEMGREP_STATEMENT
 let _: u64 = if (cond) { ... } else { s2 + <... $...SOME ...> }.f;
 
 ---
@@ -162,7 +159,6 @@ module 0xdeadbeef::mod {
 Typed Metavariables
 =======================
 
-__SEMGREP_EXPRESSION
 call(arr1, arr2, ($VAR: u32), $VAR2)
 
 ---
@@ -269,7 +265,7 @@ module 0xdeadbeef::mod {
 Function Call with Type Arguments
 =======================
 
-__SEMGREP_EXPRESSION {
+{
     borrow_global_mut<Locks<CoinType>>(...);
     exists<...> (...);
     test_fun<..., $T1, ...> (...);
@@ -319,7 +315,6 @@ __SEMGREP_EXPRESSION {
 Let Expression Match
 =======================
 
-__SEMGREP_EXPRESSION
 let test::Token { ... } = $VAR
 
 ---
@@ -342,7 +337,6 @@ let test::Token { ... } = $VAR
 Let Expr 2
 =======================
 
-__SEMGREP_EXPRESSION
 let Lock { coins, $VAR2: ..., } = ...
 
 ---
@@ -367,19 +361,21 @@ let Lock { coins, $VAR2: ..., } = ...
 Multiline Statements 1
 =======================
 
-__SEMGREP_STATEMENT ...
+...
+...
 
 ---
 
 (source_file
   (semgrep_statement
+    (ellipsis)
     (ellipsis)))
 
 =======================
 Multiline Statements 2
 =======================
 
-__SEMGREP_EXPRESSION {
+{
   let t = 100;
   ...
   t

--- a/lang/semgrep-grammars/src/semgrep-move-on-aptos/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-move-on-aptos/test/corpus/semgrep.txt
@@ -443,3 +443,24 @@ script {
         (ellipsis)))
     (declaration
       (ellipsis))))
+
+=======================
+Address Block
+=======================
+
+address $ADDR {
+  ...
+  module $MOD { ... }
+  ...
+}
+---
+
+(source_file
+  (address_block
+    (identifier)
+    (ellipsis)
+    (module
+      (identifier)
+      (declaration
+        (ellipsis)))
+    (ellipsis)))

--- a/lang/semgrep-grammars/src/semgrep-move-on-aptos/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-move-on-aptos/test/corpus/semgrep.txt
@@ -400,3 +400,46 @@ __SEMGREP_EXPRESSION {
       (var
         (name_access_chain
           (identifier))))))
+
+=======================
+Script
+=======================
+
+script {
+  ...
+  use std::vec::{...};
+  ...
+  const aa: u32 = ...;
+  ...
+  spec { ... }
+  ...
+}
+---
+
+(source_file
+  (script
+    (declaration
+      (ellipsis))
+    (declaration
+      (use_decl
+        (module_ident
+          (identifier)
+          (identifier))
+        (member
+          (ellipsis))))
+    (declaration
+      (ellipsis))
+    (declaration
+      (constant_decl
+        (identifier)
+        (type
+          (primitive_type
+            (number_type)))
+        (ellipsis)))
+    (declaration
+      (ellipsis))
+    (declaration
+      (spec_block
+        (ellipsis)))
+    (declaration
+      (ellipsis))))

--- a/lang/semgrep-grammars/src/semgrep-move-on-aptos/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-move-on-aptos/test/corpus/semgrep.txt
@@ -460,3 +460,47 @@ address $ADDR {
       (declaration
         (ellipsis)))
     (ellipsis)))
+
+
+=======================
+More Ellipsis in Field Access
+=======================
+
+let $LEFT = <... $OBJ ...>.inner;
+let $LEFT2 = ... . ... . ...;
+let $LEFT3 = ... . ... .func(...);
+
+---
+
+(source_file
+  (semgrep_statement
+    (let_expr
+      (bind_list
+        (var_name
+          (identifier)))
+      (access_field
+        (deep_ellipsis
+          (var
+            (name_access_chain
+              (identifier))))
+        (identifier)))
+    (let_expr
+      (bind_list
+        (var_name
+          (identifier)))
+      (field_access_ellipsis_expr
+        (field_access_ellipsis_expr
+          (ellipsis)
+          (ellipsis))
+        (ellipsis)))
+    (let_expr
+      (bind_list
+        (var_name
+          (identifier)))
+      (receiver_call
+        (field_access_ellipsis_expr
+          (ellipsis)
+          (ellipsis))
+        (identifier)
+        (call_args
+          (ellipsis))))))


### PR DESCRIPTION
Changes:
 - support more declaration kinds in rules
 - support partial signatures in rules
 - more flexible attribute matching
 - remove `__SEMGREP` directive tricks
 - bug fixes

### Security

- [ ] Change has no security implications (otherwise, ping the security team)
