### PR TITLE
Fix Move on sui grammar.js

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-move-on-sui/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-move-on-sui/grammar.js
@@ -7,7 +7,7 @@
 const base_grammar = require('tree-sitter-move-on-sui/grammar');
 
 module.exports = grammar(base_grammar, {
-  name: 'move',
+  name: 'move_on_sui',
 
   conflicts: ($, previous) => previous.concat([
   ]),


### PR DESCRIPTION
test plan:
cd lang
./test-lang move-on-sui
now works, without linking error


### Security

- [x] Change has no security implications (otherwise, ping the security team)