### PR TITLE
fix(dockerfile): Allow Semgrep ellipsis in healthcheck instruction

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-dockerfile/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-dockerfile/grammar.js
@@ -104,8 +104,11 @@ module.exports = grammar(base_grammar, {
         alias(/[hH][eE][aA][lL][tT][hH][cC][hH][eE][cC][kK]/, "HEALTHCHECK"),
         choice(
           $.semgrep_metavariable,
+          // To support `HEALTHCHECK ...`
+          $.semgrep_ellipsis,
           "NONE",
-          seq(repeat($.param), $.cmd_instruction)
+          // semgrep ellipsis here to support `HEALTHCHECK ... CMD echo bar`
+          seq(repeat(choice($.semgrep_ellipsis, $.param)), $.cmd_instruction)
         )
       ),
 

--- a/lang/semgrep-grammars/src/semgrep-dockerfile/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-dockerfile/test/corpus/semgrep.txt
@@ -465,6 +465,10 @@ HEALTHCHECK
 HEALTHCHECK NONE
 HEALTHCHECK --timeout=30s CMD echo hello
 HEALTHCHECK $X
+HEALTHCHECK ... CMD echo hello
+HEALTHCHECK --timeout=30s CMD ...
+HEALTHCHECK ... CMD ...
+HEALTHCHECK ...
 
 ---
 
@@ -476,7 +480,25 @@ HEALTHCHECK $X
       (shell_command
         (shell_fragment))))
   (healthcheck_instruction
-    (semgrep_metavariable)))
+    (semgrep_metavariable))
+  (healthcheck_instruction
+    (semgrep_ellipsis)
+    (cmd_instruction
+      (shell_command
+        (shell_fragment))))
+  (healthcheck_instruction
+    (param)
+    (cmd_instruction
+      (shell_command
+        (semgrep_ellipsis))))
+  (healthcheck_instruction
+    (semgrep_ellipsis)
+    (cmd_instruction
+      (shell_command
+        (semgrep_ellipsis))))
+  (healthcheck_instruction
+    (semgrep_ellipsis)))
+
 
 =============================================
 Various string literals


### PR DESCRIPTION
This had previously been omitted, so the test cases that I've added here failed to parse. When parsing dockerfile patterns, we fall back to parsing them as Bash if they fail to parse as Dockerfile. These examples parsed successfully as Bash, but the trees generated did not match, so these silently failed to match where they should.

Test plan: Automated tests.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
