### PR TITLE
Feat(move-on-aptos): v2 features

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-move-on-aptos/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-move-on-aptos/grammar.js
@@ -56,6 +56,7 @@ module.exports = grammar(base_grammar, {
       choice(
         $._function_signature,
         $._struct_signature,
+        $._enum_signature,
       )
     ),
 
@@ -214,6 +215,20 @@ module.exports = grammar(base_grammar, {
     field_access_ellipsis_expr: $ => prec.left(FIELD_PREC, seq(
       field('element', $._dot_or_index_chain), '.', $.ellipsis,
     )),
+
+    // enum variant
+    // (e.g. `enum Foo { ..., Bar }`)
+    _variant: ($, previous) => choice(
+      previous,
+      $.ellipsis,
+    ),
+
+    // match arm
+    // (e.g. `match foo { ..., bar => baz }`)
+    match_arm: ($, previous) => choice(
+      previous,
+      $.ellipsis,
+    ),
 
     // identifier, extended to support metavariables
     identifier: ($, previous) => token(choice(

--- a/lang/semgrep-grammars/src/semgrep-move-on-aptos/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-move-on-aptos/test/corpus/semgrep.txt
@@ -215,9 +215,11 @@ module 0xdeadbeef::mod {
         (identifier)
         (type_params
           (type_param
-            (identifier))
+            (type_param
+              (identifier)))
           (type_param
-            (ellipsis)))
+            (type_param
+              (ellipsis))))
         (abilities
           (ability))
         (body
@@ -553,3 +555,20 @@ let vec_2 = vector[1, 2, 3];
           (number))
         (value
           (number))))))
+
+=======================
+Return Expression
+=======================
+
+return | a;
+
+---
+
+(source_file
+  (semgrep_statement
+    (bin_op_expr
+      (return_expr)
+      (binary_operator)
+      (var
+        (name_access_chain
+          (identifier))))))

--- a/lang/semgrep-grammars/src/semgrep-move-on-aptos/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-move-on-aptos/test/corpus/semgrep.txt
@@ -504,3 +504,52 @@ let $LEFT3 = ... . ... .func(...);
         (identifier)
         (call_args
           (ellipsis))))))
+
+=======================
+Vector Expression
+=======================
+
+let vec_val = vector[...];
+let copied = vec_val[0] + vector[1][0];
+
+let vec_2 = vector[1, 2, 3];
+
+---
+
+(source_file
+  (semgrep_statement
+    (let_expr
+      (bind_list
+        (var_name
+          (identifier)))
+      (vector_value_expr
+        (ellipsis)))
+    (let_expr
+      (bind_list
+        (var_name
+          (identifier)))
+      (bin_op_expr
+        (mem_access
+          (var
+            (name_access_chain
+              (identifier)))
+          (value
+            (number)))
+        (binary_operator)
+        (mem_access
+          (vector_value_expr
+            (value
+              (number)))
+          (value
+            (number)))))
+    (let_expr
+      (bind_list
+        (var_name
+          (identifier)))
+      (vector_value_expr
+        (value
+          (number))
+        (value
+          (number))
+        (value
+          (number))))))

--- a/lang/semgrep-grammars/src/semgrep-move-on-aptos/test/corpus/v2.txt
+++ b/lang/semgrep-grammars/src/semgrep-move-on-aptos/test/corpus/v2.txt
@@ -39,7 +39,7 @@ enum CommonFields has key {
         (abilities
           (ability))
         (enum_body
-          (enum_variant
+          (enum_variant_struct
             (identifier)
             (struct_body
               (field_annot
@@ -52,7 +52,7 @@ enum CommonFields has key {
                 (type
                   (primitive_type
                     (number_type))))))
-          (enum_variant
+          (enum_variant_struct
             (identifier)
             (struct_body
               (field_annot
@@ -67,7 +67,8 @@ enum CommonFields has key {
                     (number_type))))
               (field_annot
                 (ellipsis))))
-          (identifier)
+          (enum_variant
+            (identifier))
           (ellipsis))))))
 
 =======================
@@ -232,9 +233,10 @@ enum SomeEnum<T> {
         (identifier)
         (type_params
           (type_param
-            (identifier)))
+            (type_param
+              (identifier))))
         (enum_body
-          (enum_variant
+          (enum_variant_struct
             (identifier)
             (struct_body
               (field_annot
@@ -244,7 +246,8 @@ enum SomeEnum<T> {
                     (identifier))))
               (field_annot
                 (ellipsis))))
-          (identifier))
+          (enum_variant
+            (identifier)))
         (abilities
           (ability)
           (ability)
@@ -269,9 +272,11 @@ struct AltStruct<K, V> {
         (identifier)
         (type_params
           (type_param
-            (identifier))
+            (type_param
+              (identifier)))
           (type_param
-            (identifier)))
+            (type_param
+              (identifier))))
         (struct_body
           (field_annot
             (identifier)
@@ -313,7 +318,8 @@ fun test_fun() {
         (identifier)
         (type_params
           (type_param
-            (identifier)))
+            (type_param
+              (identifier))))
         (anon_fields
           (type
             (primitive_type
@@ -388,10 +394,12 @@ fun test_fun() {
         (identifier)
         (type_params
           (type_param
-            (identifier)))
+            (type_param
+              (identifier))))
         (enum_body
-          (identifier)
           (enum_variant
+            (identifier))
+          (enum_variant_posit
             (identifier)
             (anon_fields
               (type
@@ -509,7 +517,7 @@ fun assign_enum(x: &mut E) {
       (enum_decl
         (identifier)
         (enum_body
-          (enum_variant
+          (enum_variant_posit
             (identifier)
             (anon_fields
               (type
@@ -517,7 +525,7 @@ fun assign_enum(x: &mut E) {
                   (number_type)))
               (type
                 (primitive_type))))
-          (enum_variant
+          (enum_variant_posit
             (identifier)
             (anon_fields
               (type

--- a/lang/semgrep-grammars/src/semgrep-move-on-aptos/test/corpus/v2.txt
+++ b/lang/semgrep-grammars/src/semgrep-move-on-aptos/test/corpus/v2.txt
@@ -1,0 +1,686 @@
+=======================
+Package Visibility
+=======================
+
+public(package) fun foo() { ... }
+
+---
+
+(source_file
+  (semgrep_statement
+    (declaration
+      (module_member_modifier
+        (visibility))
+      (function_decl
+        (identifier)
+        (parameters)
+        (block
+          (ellipsis))))))
+
+
+=======================
+Basic Enum
+=======================
+
+enum CommonFields has key {
+    Foo{x: u64, y: u8},
+    Bar{x: u64, z: u32, ...},
+    $VARIANT,
+    ...
+}
+
+---
+
+(source_file
+  (semgrep_statement
+    (declaration
+      (enum_decl
+        (identifier)
+        (abilities
+          (ability))
+        (enum_body
+          (enum_variant
+            (identifier)
+            (struct_body
+              (field_annot
+                (identifier)
+                (type
+                  (primitive_type
+                    (number_type))))
+              (field_annot
+                (identifier)
+                (type
+                  (primitive_type
+                    (number_type))))))
+          (enum_variant
+            (identifier)
+            (struct_body
+              (field_annot
+                (identifier)
+                (type
+                  (primitive_type
+                    (number_type))))
+              (field_annot
+                (identifier)
+                (type
+                  (primitive_type
+                    (number_type))))
+              (field_annot
+                (ellipsis))))
+          (identifier)
+          (ellipsis))))))
+
+=======================
+Match Is a Contextual Keyword
+=======================
+
+match (c) {
+    Foo{x, y: _} => {
+        let match = x > t;
+        match
+    },
+    ...,
+    _ => false
+}
+
+---
+
+(source_file
+  (semgrep_expression
+    (match_expr
+      (var
+        (name_access_chain
+          (identifier)))
+      (match_arm
+        (pattern
+          (name_access_chain
+            (identifier))
+          (fields
+            (bind_field
+              (shorthand_field_identifier
+                (identifier)))
+            (bind_field
+              (var_name
+                (identifier))
+              (var_name
+                (identifier)))))
+        (result
+          (block
+            (let_expr
+              (bind_list
+                (var_name
+                  (discouraged_name)))
+              (bin_op_expr
+                (var
+                  (name_access_chain
+                    (identifier)))
+                (binary_operator)
+                (var
+                  (name_access_chain
+                    (identifier)))))
+            (var
+              (name_access_chain
+                (discouraged_name))))))
+      (match_arm
+        (ellipsis))
+      (match_arm
+        (pattern
+          (var_name
+            (identifier)))
+        (result
+          (value
+            (bool_literal)))))))
+
+=======================
+Complex Match with Condition
+=======================
+
+match ($VAR) {
+  VariantA => $SOME,
+  VariantB{
+    field1: x,
+    field2,
+    nested: $NESTED {
+      ff,
+      ok: nak,
+    },
+    ...
+  } if ff >= 0 => {}
+  _ => ...,
+}
+
+---
+
+(source_file
+  (semgrep_expression
+    (match_expr
+      (var
+        (name_access_chain
+          (identifier)))
+      (match_arm
+        (pattern
+          (var_name
+            (identifier)))
+        (result
+          (var
+            (name_access_chain
+              (identifier)))))
+      (match_arm
+        (pattern
+          (name_access_chain
+            (identifier))
+          (fields
+            (bind_field
+              (var_name
+                (identifier))
+              (var_name
+                (identifier)))
+            (bind_field
+              (shorthand_field_identifier
+                (identifier)))
+            (bind_field
+              (var_name
+                (identifier))
+              (name_access_chain
+                (identifier))
+              (fields
+                (bind_field
+                  (shorthand_field_identifier
+                    (identifier)))
+                (bind_field
+                  (var_name
+                    (identifier))
+                  (var_name
+                    (identifier)))))
+            (bind_field
+              (ellipsis))))
+        (condition
+          (bin_op_expr
+            (var
+              (name_access_chain
+                (identifier)))
+            (binary_operator)
+            (value
+              (number))))
+        (result
+          (block)))
+      (match_arm
+        (pattern
+          (var_name
+            (identifier)))
+        (result
+          (ellipsis))))))
+
+=======================
+Alternative Enum Syntax
+=======================
+
+enum SomeEnum<T> {
+  Some {
+    value: T,
+    ...
+  },
+  None,
+} has store, key, ...;
+
+---
+
+(source_file
+  (semgrep_statement
+    (declaration
+      (enum_decl
+        (identifier)
+        (type_params
+          (type_param
+            (identifier)))
+        (enum_body
+          (enum_variant
+            (identifier)
+            (struct_body
+              (field_annot
+                (identifier)
+                (type
+                  (name_access_chain
+                    (identifier))))
+              (field_annot
+                (ellipsis))))
+          (identifier))
+        (abilities
+          (ability)
+          (ability)
+          (ability
+            (ellipsis)))))))
+
+=======================
+Alternative Struct Syntax
+=======================
+
+struct AltStruct<K, V> {
+  key: Option<K>,
+  value: V,
+} has ...;
+
+---
+
+(source_file
+  (semgrep_statement
+    (declaration
+      (struct_decl
+        (identifier)
+        (type_params
+          (type_param
+            (identifier))
+          (type_param
+            (identifier)))
+        (struct_body
+          (field_annot
+            (identifier)
+            (type
+              (name_access_chain
+                (identifier))
+              (type_args
+                (type
+                  (name_access_chain
+                    (identifier))))))
+          (field_annot
+            (identifier)
+            (type
+              (name_access_chain
+                (identifier)))))
+        (abilities
+          (ability
+            (ellipsis)))))))
+
+=======================
+Struct Positional Fields
+=======================
+
+struct Simple<T>(u64, T) has key;
+
+fun test_fun() {
+  let var = Simple<bool> (0, false);
+
+  var.1 = 5;
+  var.0 = 3;
+}
+
+---
+
+(source_file
+  (semgrep_statement
+    (declaration
+      (struct_decl
+        (identifier)
+        (type_params
+          (type_param
+            (identifier)))
+        (anon_fields
+          (type
+            (primitive_type
+              (number_type)))
+          (type
+            (name_access_chain
+              (identifier))))
+        (abilities
+          (ability))))
+    (declaration
+      (function_decl
+        (identifier)
+        (parameters)
+        (block
+          (let_expr
+            (bind_list
+              (var_name
+                (identifier)))
+            (call_expr
+              (name_access_chain
+                (identifier))
+              (type_args
+                (type
+                  (primitive_type)))
+              (call_args
+                (value
+                  (number))
+                (value
+                  (bool_literal)))))
+          (assignment
+            (access_field
+              (var
+                (name_access_chain
+                  (identifier)))
+              (anon_field_index))
+            (value
+              (number)))
+          (assignment
+            (access_field
+              (var
+                (name_access_chain
+                  (identifier)))
+              (anon_field_index))
+            (value
+              (number))))))))
+
+=======================
+Enum Positional-field Variant
+=======================
+
+enum Option<T> {
+  None,
+  Some(T),
+} has key;
+
+fun test_fun() {
+  let $X = Option::Some(...);
+
+  match ($X) {
+    None => false,
+    Some($INNER) if $INNER > 10 => true,
+    _ => false,
+  }
+}
+
+---
+
+(source_file
+  (semgrep_statement
+    (declaration
+      (enum_decl
+        (identifier)
+        (type_params
+          (type_param
+            (identifier)))
+        (enum_body
+          (identifier)
+          (enum_variant
+            (identifier)
+            (anon_fields
+              (type
+                (name_access_chain
+                  (identifier))))))
+        (abilities
+          (ability))))
+    (declaration
+      (function_decl
+        (identifier)
+        (parameters)
+        (block
+          (let_expr
+            (bind_list
+              (var_name
+                (identifier)))
+            (call_expr
+              (name_access_chain
+                (identifier)
+                (identifier))
+              (call_args
+                (ellipsis))))
+          (match_expr
+            (var
+              (name_access_chain
+                (identifier)))
+            (match_arm
+              (pattern
+                (var_name
+                  (identifier)))
+              (result
+                (value
+                  (bool_literal))))
+            (match_arm
+              (pattern
+                (name_access_chain
+                  (identifier))
+                (tuple
+                  (var_name
+                    (identifier))))
+              (condition
+                (bin_op_expr
+                  (var
+                    (name_access_chain
+                      (identifier)))
+                  (binary_operator)
+                  (value
+                    (number))))
+              (result
+                (value
+                  (bool_literal))))
+            (match_arm
+              (pattern
+                (var_name
+                  (identifier)))
+              (result
+                (value
+                  (bool_literal))))))))))
+
+
+=======================
+Complex Enum and Structs
+=======================
+
+struct S3(S2, S0, S2, ...);
+
+enum E {
+    V1(u8, bool),
+    V2(S3),
+    ...
+}
+
+fun assign_chained(x: S3) {
+    x.0.$FIELD.x + x.1.x + x.2.0.x;
+    x.0.0.x = 0;
+    x.1.x = 1;
+    x.2.0.x = 2;
+}
+
+fun assign_enum(x: &mut E) {
+    match (x) {
+        E::V1($VAR, y, ...) => {
+            *$VAR = 42;
+            *y = true;
+        },
+        E::V2(x) => {
+            x.0.0.x = 0;
+            x.1.x = 1;
+            x.2.0.x = 2;
+        },
+        ...
+    }
+}
+
+---
+
+(source_file
+  (semgrep_statement
+    (declaration
+      (struct_decl
+        (identifier)
+        (anon_fields
+          (type
+            (name_access_chain
+              (identifier)))
+          (type
+            (name_access_chain
+              (identifier)))
+          (type
+            (name_access_chain
+              (identifier)))
+          (type
+            (ellipsis)))))
+    (declaration
+      (enum_decl
+        (identifier)
+        (enum_body
+          (enum_variant
+            (identifier)
+            (anon_fields
+              (type
+                (primitive_type
+                  (number_type)))
+              (type
+                (primitive_type))))
+          (enum_variant
+            (identifier)
+            (anon_fields
+              (type
+                (name_access_chain
+                  (identifier)))))
+          (ellipsis))))
+    (declaration
+      (function_decl
+        (identifier)
+        (parameters
+          (parameter
+            (identifier)
+            (type
+              (name_access_chain
+                (identifier)))))
+        (block
+          (bin_op_expr
+            (bin_op_expr
+              (access_field
+                (access_field
+                  (access_field
+                    (var
+                      (name_access_chain
+                        (identifier)))
+                    (anon_field_index))
+                  (identifier))
+                (identifier))
+              (binary_operator)
+              (access_field
+                (access_field
+                  (var
+                    (name_access_chain
+                      (identifier)))
+                  (anon_field_index))
+                (identifier)))
+            (binary_operator)
+            (access_field
+              (access_field
+                (access_field
+                  (var
+                    (name_access_chain
+                      (identifier)))
+                  (anon_field_index))
+                (anon_field_index))
+              (identifier)))
+          (assignment
+            (access_field
+              (access_field
+                (access_field
+                  (var
+                    (name_access_chain
+                      (identifier)))
+                  (anon_field_index))
+                (anon_field_index))
+              (identifier))
+            (value
+              (number)))
+          (assignment
+            (access_field
+              (access_field
+                (var
+                  (name_access_chain
+                    (identifier)))
+                (anon_field_index))
+              (identifier))
+            (value
+              (number)))
+          (assignment
+            (access_field
+              (access_field
+                (access_field
+                  (var
+                    (name_access_chain
+                      (identifier)))
+                  (anon_field_index))
+                (anon_field_index))
+              (identifier))
+            (value
+              (number))))))
+    (declaration
+      (function_decl
+        (identifier)
+        (parameters
+          (parameter
+            (identifier)
+            (type
+              (name_access_chain
+                (identifier)))))
+        (block
+          (match_expr
+            (var
+              (name_access_chain
+                (identifier)))
+            (match_arm
+              (pattern
+                (name_access_chain
+                  (identifier)
+                  (identifier))
+                (tuple
+                  (var_name
+                    (identifier))
+                  (var_name
+                    (identifier))
+                  (ellipsis)))
+              (result
+                (block
+                  (assignment
+                    (deref_expr
+                      (var
+                        (name_access_chain
+                          (identifier))))
+                    (value
+                      (number)))
+                  (assignment
+                    (deref_expr
+                      (var
+                        (name_access_chain
+                          (identifier))))
+                    (value
+                      (bool_literal))))))
+            (match_arm
+              (pattern
+                (name_access_chain
+                  (identifier)
+                  (identifier))
+                (tuple
+                  (var_name
+                    (identifier))))
+              (result
+                (block
+                  (assignment
+                    (access_field
+                      (access_field
+                        (access_field
+                          (var
+                            (name_access_chain
+                              (identifier)))
+                          (anon_field_index))
+                        (anon_field_index))
+                      (identifier))
+                    (value
+                      (number)))
+                  (assignment
+                    (access_field
+                      (access_field
+                        (var
+                          (name_access_chain
+                            (identifier)))
+                        (anon_field_index))
+                      (identifier))
+                    (value
+                      (number)))
+                  (assignment
+                    (access_field
+                      (access_field
+                        (access_field
+                          (var
+                            (name_access_chain
+                              (identifier)))
+                          (anon_field_index))
+                        (anon_field_index))
+                      (identifier))
+                    (value
+                      (number))))))
+            (match_arm
+              (ellipsis))))))))


### PR DESCRIPTION
- Move on aptos v2 features:
  - Enum
  - Match pattern
  - Positional fields
  - Package visibility
  - Alternative syntax for struct and enum
- Bug fixes
  - `vector[...]` is correctly parsed
  - Change `return`'s precedence
  - Some grammar clean-ups

### Security

- [x] Change has no security implications (otherwise, ping the security team)
