### PR TITLE
Fix C# regression in preprocessor directive parsing

### DIFF
--- a/lang/c-sharp-pro/test/ok/preproc_stmts.cs
+++ b/lang/c-sharp-pro/test/ok/preproc_stmts.cs
@@ -1,0 +1,7 @@
+void F()
+{
+#if DEBUG
+    a();
+    b();
+#endif
+}

--- a/lang/semgrep-grammars/src/semgrep-c-sharp-pro/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-c-sharp-pro/grammar.js
@@ -113,12 +113,12 @@ module.exports = grammar(standard_grammar, {
 
     // use syntax similar to a cast_expression, but with metavar
     //TODO: use PREC.CAST from original grammar instead of 17 below
-    typed_metavariable: $ => prec.right(17, seq(
+    typed_metavariable: $ => prec(17, prec.dynamic(1, seq(
       '(',
       field('type', $.type),
       field('metavar', $._semgrep_metavariable),
       ')',
-    )),
+    ))),
 
     deep_ellipsis: $ => seq(
       '<...', $.expression, '...>'

--- a/lang/semgrep-grammars/src/semgrep-c-sharp-pro/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-c-sharp-pro/grammar.js
@@ -17,8 +17,6 @@ module.exports = grammar(standard_grammar, {
   conflicts: ($, previous) => [
     ...previous,
     [$.expression, $.parameter],
-    [$.file_scoped_namespace_declaration, $.preproc_if_in_top_level],
-    [$.file_scoped_namespace_declaration, $.preproc_else_in_top_level],
   ],
 
   rules: {
@@ -74,20 +72,6 @@ module.exports = grammar(standard_grammar, {
       return choice(
         ...previous.members,
         $.ellipsis
-      )
-    },
-
-    // We do this because a file scoped namespace declaration is a top-level 
-    // thing, but ellipses are more particular. We want ellipses to be used 
-    // in conjunction with file scoped namespace declarations.
-    // Unfortunately, in the base grammar, we can either have ellipsis 
-    // statements, or a file scoped declaration! That's no good. To play 
-    // around the previous grammar, we simply allow what came before to also 
-    // occur before a file scoped namespace declaration.
-    file_scoped_namespace_declaration: ($, previous) => {
-      return seq(
-        seq(repeat($.global_statement), repeat($._namespace_member_declaration)),
-        previous,
       )
     },
 

--- a/lang/semgrep-grammars/src/semgrep-c-sharp-pro/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-c-sharp-pro/test/corpus/semgrep.txt
@@ -260,6 +260,52 @@ __SEMGREP_EXPRESSION
         (identifier))
       (argument_list))))
 
+===============================================================================
+Typed metavariable 2
+===============================================================================
+
+__SEMGREP_EXPRESSION (T $X)
+
+---
+
+(compilation_unit
+  (semgrep_expression
+    (typed_metavariable
+      (identifier))))
+
+===============================================================================
+Typed metavariable 3
+===============================================================================
+
+__SEMGREP_EXPRESSION (List<T> $X)
+
+---
+
+(compilation_unit
+  (semgrep_expression
+    (typed_metavariable
+      (generic_name
+        (identifier)
+        (type_argument_list
+          (identifier))))))
+
+===============================================================================
+Cast expression
+===============================================================================
+
+__SEMGREP_EXPRESSION (List<T>) x
+
+---
+
+(compilation_unit
+  (semgrep_expression
+    (cast_expression
+      (generic_name
+        (identifier)
+        (type_argument_list
+          (identifier)))
+      (identifier))))
+
 ================================================================================
 Ellipses + metavariables as args
 ================================================================================
@@ -404,9 +450,9 @@ void F()
               (identifier)
               (argument_list))))))))
 
-================================================================================
+===============================================================================
 Preprocessor conditional with multiple statements
-================================================================================
+===============================================================================
 
 void F()
 {
@@ -435,3 +481,4 @@ void F()
             (invocation_expression
               (identifier)
               (argument_list))))))))
+

--- a/lang/semgrep-grammars/src/semgrep-c-sharp-pro/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-c-sharp-pro/test/corpus/semgrep.txt
@@ -376,3 +376,62 @@ namespace $N;
   (global_statement
     (expression_statement
       (ellipsis))))
+
+================================================================================
+Preprocessor conditional with single statement
+================================================================================
+
+void F()
+{
+#if DEBUG
+    a();
+#endif
+}
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_function_statement
+      (predefined_type)
+      (identifier)
+      (parameter_list)
+      (block
+        (preproc_if
+          (identifier)
+          (expression_statement
+            (invocation_expression
+              (identifier)
+              (argument_list))))))))
+
+================================================================================
+Preprocessor conditional with multiple statements
+================================================================================
+
+void F()
+{
+#if DEBUG
+    a();
+    b();
+#endif
+}
+
+---
+
+(compilation_unit
+  (global_statement
+    (local_function_statement
+      (predefined_type)
+      (identifier)
+      (parameter_list)
+      (block
+        (preproc_if
+          (identifier)
+          (expression_statement
+            (invocation_expression
+              (identifier)
+              (argument_list)))
+          (expression_statement
+            (invocation_expression
+              (identifier)
+              (argument_list))))))))

--- a/lang/semgrep-grammars/src/semgrep-c-sharp/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-c-sharp/test/corpus/semgrep.txt
@@ -267,6 +267,35 @@ __SEMGREP_EXPRESSION
         (identifier))
       (argument_list))))
 
+===============================================================================
+Typed metavariable 2
+===============================================================================
+
+__SEMGREP_EXPRESSION (T $X)
+
+---
+
+(compilation_unit
+  (semgrep_expression
+    (typed_metavariable
+      (identifier))))
+
+===============================================================================
+Typed metavariable 3
+===============================================================================
+
+__SEMGREP_EXPRESSION (List<T> $X)
+
+---
+
+(compilation_unit
+  (semgrep_expression
+    (typed_metavariable
+      (generic_name
+        (identifier)
+        (type_argument_list
+          (identifier))))))
+
 ================================================================================
 Ellipses + metavariables as args
 ================================================================================


### PR DESCRIPTION
It was due to a left-over syntax extension workaround that no longer applies and was causing conflicts.

This also fixes incorrect parsing of typed metavariables where the type is parametrized. The problem occurred just now in Semgrep and didn't have a test for this specific case (e.g. `(List<T> $X)` was parsed as `(List < T) > $X)`).

Integration work in progress at https://github.com/semgrep/semgrep-proprietary/pull/2390

### Checklist

- [x] Any new parsing code was already published, integrated, and merged into Semgrep. DO NOT MERGE THIS PR BEFORE THE SEMGREP INTEGRATION WORK WAS COMPLETED.
- [x] Change has no security implications (otherwise, ping the security team)
