### PR TITLE
chore: move sca langs to pro

### DIFF
--- a/lang/release
+++ b/lang/release
@@ -64,7 +64,7 @@ fi
 # Language-specific options
 GEN_OCAML_OPTIONS=""
 case "$lang" in
-  apex|c-sharp-pro|elixir)
+  apex|c-sharp-pro|elixir|gomod|requirements|toml)
     GEN_OCAML_OPTIONS="--package tree-sitter-lang-pro"
     ;;
   *)


### PR DESCRIPTION
We don't use these languages for code, and we've only been using them in Pro.


### Checklist

- [ ] Any new parsing code was already published, integrated, and merged into Semgrep. DO NOT MERGE THIS PR BEFORE THE SEMGREP INTEGRATION WORK WAS COMPLETED.
- [ ] Change has no security implications (otherwise, ping the security team)
