### PR TITLE
fix(ts): add assign lambda case

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-typescript/common/semgrep-ext.js
+++ b/lang/semgrep-grammars/src/semgrep-typescript/common/semgrep-ext.js
@@ -53,6 +53,25 @@ module.exports = {
       $.semgrep_ellipsis,
     ),
 
+    // For `var $X = $FUNC($REQ, $RES, ...) {...}`.
+    // Unfortunately, it seems we used to allow this pattern, which really should
+    // have a `function` keyword.
+    // It normally fails to parse because we insert a semicolon
+    // var $X = $FUNC($REQ, $RES, ...) {...}
+    //                                ^ here
+    // and don't know how to interpret it properly.
+    assign_lambda: $ => seq(
+      'var',
+      field('name', choice($.identifier, $._destructuring_pattern)),
+      '=',
+      // Notably, we cannot use `function_expression` here, which would expect
+      // a `function` keyword!
+      // $.function_expression,
+      field('name', optional($.identifier)),
+      $._call_signature,
+      field('body', $.statement_block),
+    ),
+
     semgrep_pattern: $ => choice(
       $.expression,
       $.pair,
@@ -60,6 +79,7 @@ module.exports = {
       $.function_declaration_pattern,
       $.finally_clause,
       $.catch_clause,
+      $.assign_lambda,
     ),
 
     method_pattern: $ => choice(

--- a/lang/typescript/test/ok/semgrep/assign_lambda.sgrep
+++ b/lang/typescript/test/ok/semgrep/assign_lambda.sgrep
@@ -1,0 +1,1 @@
+__SEMGREP_EXPRESSION var $X = $FUNC($REQ, $RES, ...) { ... }


### PR DESCRIPTION
This PR makes it so we can parse the pattern `var $X = $FUNC($REQ, $RES, ...) {...}`.

### Checklist

- [ ] Any new parsing code was already published, integrated, and merged into Semgrep. DO NOT MERGE THIS PR BEFORE THE SEMGREP INTEGRATION WORK WAS COMPLETED.
- [X] Change has no security implications (otherwise, ping the security team)
