### PR TITLE
Use uv and GitPython in grammar-update scripts

### DIFF
--- a/.github/workflows/propose-grammar-updates.yml
+++ b/.github/workflows/propose-grammar-updates.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
       - id: list
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
       # The org requires verified (signed) commits on all branches, so the
@@ -155,9 +155,6 @@ jobs:
       # This step must come AFTER `make install` populates that dir.
       - name: Put pinned tree-sitter CLI on PATH
         run: echo "$GITHUB_WORKSPACE/core/tree-sitter/bin" >> "$GITHUB_PATH"
-      # keep-mode commits run pre-commit before staging; install it for CI.
-      - name: Install pre-commit
-        run: uv tool install pre-commit
       # The review agent (Cursor dispatch on a failing test-lang) is an
       # explicit opt-in via the run_review_agent input: without it, neither
       # the CLI nor the API key is even present on the runner, so no grammar
@@ -219,7 +216,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -312,7 +309,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/propose-grammar-updates.yml
+++ b/.github/workflows/propose-grammar-updates.yml
@@ -49,6 +49,9 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
+        with:
+          enable-cache: true
       - id: list
         # A single dispatched language overrides the full set. The input is
         # untrusted, so it goes through an env var (never interpolated into
@@ -64,14 +67,14 @@ jobs:
           if [ -n "$INPUT_LANGUAGE" ] && [ "$INPUT_LANGUAGE" != "all" ]; then
             # Single named language: validate against the FULL set (a manual
             # run may target a language even just to re-check it — no filter).
-            valid=$(python scripts/propose-grammar-update --list-languages --json)
+            valid=$(uv run scripts/propose-grammar-update --list-languages --json)
             echo "$valid" | python -c "import json,sys; ls=json.load(sys.stdin); sys.exit(0 if sys.argv[1] in ls else 1)" "$INPUT_LANGUAGE" \
               || { echo "Unknown language: $INPUT_LANGUAGE" >&2; exit 1; }
             echo "languages=$(python -c 'import json,os; print(json.dumps([os.environ["INPUT_LANGUAGE"]]))')" >> "$GITHUB_OUTPUT"
           else
             # 'all'/blank/scheduled: only languages actually behind their latest
             # tag, so up-to-date ones never enter the expensive build matrix.
-            echo "languages=$(python scripts/propose-grammar-update --list-languages --updatable-only --json)" >> "$GITHUB_OUTPUT"
+            echo "languages=$(uv run scripts/propose-grammar-update --list-languages --updatable-only --json)" >> "$GITHUB_OUTPUT"
           fi
 
   propose:
@@ -100,6 +103,9 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
+        with:
+          enable-cache: true
       # The org requires verified (signed) commits on all branches, so the
       # bump commit must be GPG-signed by a key registered on the authoring
       # GitHub account. Import the bot key and turn on signing globally.
@@ -149,6 +155,9 @@ jobs:
       # This step must come AFTER `make install` populates that dir.
       - name: Put pinned tree-sitter CLI on PATH
         run: echo "$GITHUB_WORKSPACE/core/tree-sitter/bin" >> "$GITHUB_PATH"
+      # keep-mode commits run pre-commit before staging; install it for CI.
+      - name: Install pre-commit
+        run: uv tool install pre-commit
       # The review agent (Cursor dispatch on a failing test-lang) is an
       # explicit opt-in via the run_review_agent input: without it, neither
       # the CLI nor the API key is even present on the runner, so no grammar
@@ -177,7 +186,7 @@ jobs:
           if [ "$DRY_RUN" = "true" ]; then mode="--dry-run"; fi
           flags=""
           if [ "$RUN_REVIEW_AGENT" = "true" ]; then flags="--review-agent"; fi
-          opam exec -- python scripts/propose-grammar-update "${{ matrix.language }}" $mode $flags \
+          opam exec -- uv run scripts/propose-grammar-update "${{ matrix.language }}" $mode $flags \
             | tee "result-${{ matrix.language }}.json"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
@@ -210,6 +219,9 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
+        with:
+          enable-cache: true
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: result-${{ matrix.language }}
@@ -283,7 +295,7 @@ jobs:
           # lang/release -> make gen-c needs `ocaml-tree-sitter` on PATH.
           # --result: release the exact tag/branch the propose job validated
           # (from its artifact), never a live re-resolved one.
-          opam exec -- python scripts/propose-grammar-update "${{ matrix.language }}" --release \
+          opam exec -- uv run scripts/propose-grammar-update "${{ matrix.language }}" --release \
             --result "result/result-${{ matrix.language }}.json"
 
   summary:
@@ -300,9 +312,12 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
+        with:
+          enable-cache: true
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: results
           merge-multiple: true
       - name: Render summary
-        run: python scripts/propose-grammar-update --summarize results >> "$GITHUB_STEP_SUMMARY"
+        run: uv run scripts/propose-grammar-update --summarize results >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/propose-grammar-updates.yml
+++ b/.github/workflows/propose-grammar-updates.yml
@@ -158,6 +158,8 @@ jobs:
         run: |
           curl https://cursor.com/install -fsS | bash
           echo "$HOME/.cursor/bin" >> "$GITHUB_PATH"
+      - name: Install Python dependencies
+        run: python -m pip install --upgrade pip 'gitpython>=3.1.0'
       - name: Propose update
         env:
           # NOTE: PRs created with GITHUB_TOKEN do not trigger other GitHub

--- a/.github/workflows/propose-grammar-updates.yml
+++ b/.github/workflows/propose-grammar-updates.yml
@@ -158,8 +158,6 @@ jobs:
         run: |
           curl https://cursor.com/install -fsS | bash
           echo "$HOME/.cursor/bin" >> "$GITHUB_PATH"
-      - name: Install Python dependencies
-        run: python -m pip install --upgrade pip 'gitpython>=3.1.0'
       - name: Propose update
         env:
           # NOTE: PRs created with GITHUB_TOKEN do not trigger other GitHub

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -50,4 +50,4 @@ jobs:
           enable-cache: true
 
       - name: Run Python tests (make test-python)
-        run: uv run pytest scripts/test_update_grammar.py
+        run: make test-python

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -46,7 +46,4 @@ jobs:
           done
 
       - name: Run Python tests (make test-python)
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install 'pytest>=8,<9' 'gitpython>=3.1.0'
-          make test-python
+        run: uv run pytest scripts/test_update_grammar.py

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -44,6 +44,10 @@ jobs:
             chmod +x "$dir/tree-sitter"
             "$dir/tree-sitter" --version
           done
+      - name: Set up uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
+        with:
+          enable-cache: true
 
       - name: Run Python tests (make test-python)
         run: uv run pytest scripts/test_update_grammar.py

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -48,5 +48,5 @@ jobs:
       - name: Run Python tests (make test-python)
         run: |
           python -m pip install --upgrade pip
-          python -m pip install 'pytest>=8,<9'
+          python -m pip install 'pytest>=8,<9' 'gitpython>=3.1.0'
           make test-python

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -45,7 +45,7 @@ jobs:
             "$dir/tree-sitter" --version
           done
       - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ bindings/
 
 # Python temps
 __pycache__
+
+# uv virtual environment
+.venv

--- a/Makefile
+++ b/Makefile
@@ -47,15 +47,11 @@ test: build
 
 # Run the Python test suites (not run by 'make test'). For full coverage, the
 # pinned tree-sitter versions must be installed ('make setup-tree-sitter-versions').
-# Uses the 'pytest' on PATH if present, otherwise falls back to 'python3 -m pytest'.
+# Dependencies are managed by uv via pyproject.toml.
 PYTHON_TESTS = lang/test_grammar_ts_version.py lang/test_ts_versions.py lang/test_abi15_gating.py scripts/test_update_grammar.py scripts/test_propose_grammar_update.py
 .PHONY: test-python
 test-python:
-	@if command -v pytest >/dev/null 2>&1; then \
-	  pytest $(PYTHON_TESTS); \
-	else \
-	  python3 -m pytest $(PYTHON_TESTS); \
-	fi
+	uv run pytest $(PYTHON_TESTS)
 
 # Install every tree-sitter version the grammars are pinned to (derived from the
 # lang/languages-* files), each into its own core/tree-sitter-<version>/. Needed

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ test: build
 PYTHON_TESTS = lang/test_grammar_ts_version.py lang/test_ts_versions.py lang/test_abi15_gating.py scripts/test_update_grammar.py scripts/test_propose_grammar_update.py
 .PHONY: test-python
 test-python:
-	uv run pytest $(PYTHON_TESTS)
+	uv run --extra dev pytest $(PYTHON_TESTS)
 
 # Install every tree-sitter version the grammars are pinned to (derived from the
 # lang/languages-* files), each into its own core/tree-sitter-<version>/. Needed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,8 @@ requires-python = ">=3.10"
 dependencies = [
     "gitpython>=3.1.0",
 ]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8,<9",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.uv]
+exclude-newer = "1 week"
+
+[project]
+name = "ocaml-tree-sitter-semgrep"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "gitpython>=3.1.0",
+]

--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -706,9 +706,8 @@ def propose(root: Path, target: Target, keep: bool = False,
 
         result.status = STATUS_UPDATED
         if keep:
-            # Commit the validated tree on the branch — this is exactly what
-            # was tested. Exclude the workflow's result artifact and `core`
-            # (a grammar bump must only move the language submodule).
+            # Run pre-commit on changed files to fix auto-fixable issues before staging.
+            run_quiet(["pre-commit", "run", "--files", "lang/"], cwd=root)
             run_quiet(["git", "add", "-A", "--", ".",
                        ":(exclude)result-*.json", ":(exclude)core"], cwd=root)
             run_quiet(["git", "commit", "-m",

--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -712,16 +712,9 @@ def propose(root: Path, target: Target, keep: bool = False,
 
         result.status = STATUS_UPDATED
         if keep:
-            # Run pre-commit on changed files to fix auto-fixable issues before staging.
-            # pre-commit exits 1 if it made changes (non-fatal), so check=False
-            precommit = subprocess.run(
-                ["pre-commit", "run", "--files", "lang/"],
-                cwd=root, capture_output=True, text=True, check=False,
-            )
-            if precommit.returncode not in (0, 1):
-                raise subprocess.CalledProcessError(
-                    precommit.returncode, precommit.args,
-                    precommit.stdout, precommit.stderr)
+            # Commit the validated tree on the branch — this is exactly what
+            # was tested. Exclude the workflow's result artifact and `core`
+            # (a grammar bump must only move the language submodule).
             commit_repo = git.Repo(root)
             commit_repo.git.add("-A", "--", ".",
                                 ":(exclude)result-*.json", ":(exclude)core")

--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -156,11 +156,11 @@ def log(msg: str) -> None:
 
 
 def git_query(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess:
-    """Run a read-only git query quietly (no command echo, never raises).
+    """Run a read-only, non-git query quietly (no command echo, never raises).
 
-    `update-grammar`'s `run` echoes every command to stderr, which is
-    noise for the many read-only probes here. Use this for queries;
-    reserve `ug.run` for mutating steps where live output is wanted.
+    All actual git operations go through GitPython; this remains for the
+    non-git read-only probes here (`gh`, `tree-sitter`) where a bare
+    CompletedProcess is the simplest fit.
     """
     return subprocess.run(
         cmd, cwd=cwd, text=True, capture_output=True, check=False,
@@ -168,13 +168,13 @@ def git_query(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess:
 
 
 def run_quiet(cmd: list[str], cwd: Path) -> None:
-    """Run a mutating command, mirroring its output to STDERR, raising on error.
+    """Run a mutating `gh` command, mirroring its output to STDERR, raising on error.
 
-    stdout is reserved for the single JSON result line, so git/gh output
+    stdout is reserved for the single JSON result line, so gh output
     must never go there (it would corrupt the contract and the workflow's
     `tee`'d artifact). The child's stderr is merged into its stdout at
     capture time (stderr=STDOUT) so the re-emitted log keeps the original
-    interleaving.
+    interleaving. Git operations go through GitPython instead.
     """
     log(f"$ {' '.join(cmd)}  (in {cwd})")
     r = subprocess.run(cmd, cwd=cwd, text=True, check=False,
@@ -204,25 +204,28 @@ def gitmodules_url(root: Path, submodule: Path) -> str | None:
     keys in CI.
     """
     rel = submodule.relative_to(root).as_posix()
-    result = git_query(
-        ["git", "config", "-f", ".gitmodules", "--get-regexp", r"\.path$"],
-        cwd=root,
-    )
-    section = None
-    for line in result.stdout.splitlines():
-        key, _, path = line.partition(" ")
-        if path == rel:
-            section = key[: -len(".path")]
-            break
-    if section is None:
-        return None
-    url = git_query(
-        ["git", "config", "-f", ".gitmodules", "--get", f"{section}.url"],
-        cwd=root,
-    ).stdout.strip()
-    if not url:
-        return None
+    with git.GitConfigParser(str(root / ".gitmodules"), read_only=True) as cfg:
+        section = next(
+            (s for s in cfg.sections()
+             if cfg.has_option(s, "path") and cfg.get(s, "path") == rel),
+            None,
+        )
+        if section is None or not cfg.has_option(section, "url"):
+            return None
+        url = cfg.get(section, "url")
     return url.replace("git@github.com:", "https://github.com/")
+
+
+def ls_remote(*args: str, cwd: Path | None = None) -> str:
+    """Run `git ls-remote` via GitPython, returning "" if it fails.
+
+    `cwd` matters when `args` names a configured remote (e.g. "origin")
+    rather than a bare URL, so it resolves against the right repo.
+    """
+    try:
+        return git.Git(cwd).ls_remote(*args)
+    except git.GitCommandError:
+        return ""
 
 
 def latest_stable_tag(url: str) -> str | None:
@@ -232,12 +235,10 @@ def latest_stable_tag(url: str) -> str | None:
     and non-version tag schemes are ignored), and returns the highest by
     numeric version.
     """
-    result = git_query(["git", "ls-remote", "--tags", "--refs", url], cwd=Path.cwd())
-    if result.returncode != 0:
-        return None
+    out = ls_remote("--tags", "--refs", url)
     tags = [
         line.split("refs/tags/", 1)[1]
-        for line in result.stdout.splitlines()
+        for line in out.splitlines()
         if "refs/tags/" in line
     ]
     stable = [t for t in tags if _STABLE_TAG_RE.match(t)]
@@ -309,10 +310,7 @@ def tag_commit_sha(url: str, tag: str) -> str | None:
     tag OBJECT, which would never match a gitlink commit SHA. Prefer the
     peeled line; lightweight tags have no peeled line, so fall back.
     """
-    out = git_query(
-        ["git", "ls-remote", url, f"refs/tags/{tag}^{{}}", f"refs/tags/{tag}"],
-        cwd=Path.cwd(),
-    ).stdout
+    out = ls_remote(url, f"refs/tags/{tag}^{{}}", f"refs/tags/{tag}")
     peeled = plain = None
     for line in out.splitlines():
         parts = line.split()
@@ -384,10 +382,8 @@ def regenerate_snapshots(root: Path, wrapper: str) -> None:
 
 def corpus_diff(root: Path, wrapper: str) -> str:
     """Return the working-tree diff of the wrapper's corpus snapshots."""
-    return git_query(
-        ["git", "diff", "--", str(wrapper_dir(root, wrapper) / "test" / "corpus")],
-        cwd=root,
-    ).stdout
+    return git.Repo(root).git.diff(
+        "--", str(wrapper_dir(root, wrapper) / "test" / "corpus"))
 
 
 def run_test_lang(language: str, root: Path) -> subprocess.CompletedProcess:
@@ -450,16 +446,9 @@ def proposal_exists(root: Path, branch: str) -> bool:
     Cheap pre-check so a re-run doesn't rebuild/re-PR an in-flight update.
     Checks origin (the durable signal) and any local branch.
     """
-    remote = git_query(
-        ["git", "ls-remote", "--heads", "origin", branch], cwd=root,
-    ).stdout.strip()
-    if remote:
+    if ls_remote("--heads", "origin", branch, cwd=root).strip():
         return True
-    local = git_query(
-        ["git", "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}"],
-        cwd=root,
-    )
-    return local.returncode == 0
+    return branch in git.Repo(root).heads
 
 
 def existing_proposal(root: Path, target: Target) -> Result | None:
@@ -551,7 +540,8 @@ def open_pr(root: Path, target: Target, result: Result,
         result.detail = f"branch {branch} already exists"
         return result
 
-    run_quiet(["git", "push", "origin", branch], cwd=root)
+    log(f"$ git push origin {branch}  (in {root})")
+    git.Repo(root).remotes.origin.push(branch)
     create = ["gh", "pr", "create", "--title", title, "--body", body,
               "--base", base, "--head", branch]
     # Flag PRs where the skill adapted test expectations so reviewers look closely.
@@ -666,8 +656,11 @@ def propose(root: Path, target: Target, keep: bool = False,
     committed = False
     if keep:
         base = base_branch()
-        run_quiet(["git", "fetch", "origin", base], cwd=root)
-        run_quiet(["git", "checkout", "-B", branch, f"origin/{base}"], cwd=root)
+        repo = git.Repo(root)
+        log(f"$ git fetch origin {base}  (in {root})")
+        repo.remotes.origin.fetch(base)
+        log(f"$ git checkout -B {branch} origin/{base}  (in {root})")
+        repo.git.checkout("-B", branch, f"origin/{base}")
 
     try:
         # A non-zero bump with a MOVED submodule is expected (update-grammar's
@@ -721,16 +714,19 @@ def propose(root: Path, target: Target, keep: bool = False,
         if keep:
             # Run pre-commit on changed files to fix auto-fixable issues before staging.
             # pre-commit exits 1 if it made changes (non-fatal), so check=False
-            result = subprocess.run(
+            precommit = subprocess.run(
                 ["pre-commit", "run", "--files", "lang/"],
                 cwd=root, capture_output=True, text=True, check=False,
             )
-            if result.returncode not in (0, 1):
-                raise subprocess.CalledProcessError(result.returncode, result.args, result.stdout, result.stderr)
-            run_quiet(["git", "add", "-A", "--", ".",
-                       ":(exclude)result-*.json", ":(exclude)core"], cwd=root)
-            run_quiet(["git", "commit", "-m",
-                       f"Update tree-sitter-{language} grammar to {tag}"], cwd=root)
+            if precommit.returncode not in (0, 1):
+                raise subprocess.CalledProcessError(
+                    precommit.returncode, precommit.args,
+                    precommit.stdout, precommit.stderr)
+            commit_repo = git.Repo(root)
+            commit_repo.git.add("-A", "--", ".",
+                                ":(exclude)result-*.json", ":(exclude)core")
+            commit_repo.git.commit(
+                "-m", f"Update tree-sitter-{language} grammar to {tag}")
             committed = True
             result.branch = branch
         return result
@@ -1019,10 +1015,15 @@ def run_release(root: Path, target: Target, dry_run: bool,
     # that could pull different content than what test-lang actually
     # validated. `lang/release` regenerates the OCaml sources from this tree
     # via its own `make gen`.
-    run_quiet(["git", "fetch", "origin", branch], cwd=root)
-    run_quiet(["git", "checkout", branch], cwd=root)
-    run_quiet(["git", "submodule", "update", "--init", "--recursive", "--depth", "1",
-               "--", str(target.submodule.relative_to(root))], cwd=root)
+    repo = git.Repo(root)
+    log(f"$ git fetch origin {branch}  (in {root})")
+    repo.remotes.origin.fetch(branch)
+    log(f"$ git checkout {branch}  (in {root})")
+    repo.git.checkout(branch)
+    sub_rel = str(target.submodule.relative_to(root))
+    log(f"$ git submodule update --init --recursive --depth 1 -- {sub_rel}  (in {root})")
+    repo.git.submodule("update", "--init", "--recursive", "--depth", "1",
+                       "--", sub_rel)
 
     rel = release_downstream(root, language, wrapper, branch, tag, dry_run=dry_run)
     if rel is not None and rel.returncode != 0:

--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -1,4 +1,4 @@
-#!/usr/bin/env uv
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
@@ -720,7 +720,13 @@ def propose(root: Path, target: Target, keep: bool = False,
         result.status = STATUS_UPDATED
         if keep:
             # Run pre-commit on changed files to fix auto-fixable issues before staging.
-            run_quiet(["pre-commit", "run", "--files", "lang/"], cwd=root)
+            # pre-commit exits 1 if it made changes (non-fatal), so check=False
+            result = subprocess.run(
+                ["pre-commit", "run", "--files", "lang/"],
+                cwd=root, capture_output=True, text=True, check=False,
+            )
+            if result.returncode not in (0, 1):
+                raise subprocess.CalledProcessError(result.returncode, result.args, result.stdout, result.stderr)
             run_quiet(["git", "add", "-A", "--", ".",
                        ":(exclude)result-*.json", ":(exclude)core"], cwd=root)
             run_quiet(["git", "commit", "-m",

--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -1,4 +1,10 @@
-#!/usr/bin/env python3
+#!/usr/bin/env uv
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "gitpython>=3.1.0",
+# ]
+# ///
 """Propose an upstream grammar update for a single language.
 
 This is the per-language driver behind the scheduled "propose grammar
@@ -49,6 +55,8 @@ from importlib.machinery import SourceFileLoader
 from importlib.util import module_from_spec, spec_from_loader
 from pathlib import Path
 from typing import Any
+
+import git
 
 ###############################################################################
 # update-grammar import #

--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -284,18 +284,20 @@ def resolve_target(root: Path, language: str) -> Target:
 
 
 def submodule_head(submodule: Path) -> str:
-    """Return the submodule's current HEAD SHA."""
-    return git_query(["git", "rev-parse", "HEAD"], cwd=submodule).stdout.strip()
+    """Return the submodule's current HEAD SHA using GitPython."""
+    repo = git.Repo(submodule)
+    return repo.head.commit.hexsha
 
 
 def recorded_submodule_sha(root: Path, submodule: Path) -> str | None:
-    """Return the submodule SHA recorded in the outer repo's index (HEAD).
+    """Return the submodule SHA recorded in the outer repo's index (HEAD) using GitPython.
 
-    Reads the committed gitlink via `git ls-tree` — no submodule checkout
+    Reads the committed gitlink via ls-tree — no submodule checkout
     needed, so this is cheap enough for the enumerate pre-filter.
     """
     rel = submodule.relative_to(root).as_posix()
-    out = git_query(["git", "ls-tree", "HEAD", rel], cwd=root).stdout.split()
+    repo = git.Repo(root)
+    out = repo.git.ls_tree("HEAD", rel).split()
     return out[2] if len(out) >= 3 else None
 
 
@@ -397,18 +399,21 @@ def run_test_lang(language: str, root: Path) -> subprocess.CompletedProcess:
 
 
 def reset_language_state(root: Path, submodule: Path, old_sha: str) -> None:
-    """Undo every mutation, so a failure never leaks into the next run.
+    """Undo every mutation using GitPython, so a failure never leaks into the next run.
 
     Mirrors what `update-grammar` leaves behind on a failed run: a
     detached/bumped submodule, edited languages-* files, deleted/regenerated
     parser.c, and regenerated snapshots. Restores the submodule to
     `old_sha` and the outer tree to HEAD.
     """
-    git_query(["git", "restore", "--staged", "."], cwd=root)
-    git_query(["git", "checkout", "--", "lang"], cwd=root)
-    git_query(["git", "checkout", old_sha], cwd=submodule)
-    git_query(["git", "checkout", "--", "."], cwd=submodule)
-    git_query(["git", "clean", "-fdq"], cwd=submodule)
+    root_repo = git.Repo(root)
+    root_repo.git.restore("--staged", ".")
+    root_repo.git.checkout("--", "lang")
+
+    sub_repo = git.Repo(submodule)
+    sub_repo.git.checkout(old_sha)
+    sub_repo.git.checkout("--", ".")
+    sub_repo.git.clean("-fdq")
 
 
 def tail(text: str, lines: int = 40) -> str:

--- a/scripts/test_propose_grammar_update.py
+++ b/scripts/test_propose_grammar_update.py
@@ -422,11 +422,7 @@ class TestTagCommitSha(unittest.TestCase):
     """
 
     def _with_ls_remote(self, stdout):
-        import subprocess as sp
-        return unittest.mock.patch.object(
-            pg, "git_query",
-            lambda cmd, cwd: sp.CompletedProcess(cmd, 0, stdout, ""),
-        )
+        return unittest.mock.patch.object(pg, "ls_remote", lambda *a: stdout)
 
     def test_annotated_tag_prefers_peeled_sha(self):
         out = ("tagobj111\trefs/tags/v1.0.0\n"

--- a/scripts/test_update_grammar.py
+++ b/scripts/test_update_grammar.py
@@ -601,6 +601,12 @@ class EnsureOnBranchTests(GitRepoTest):
         ug.ensure_on_branch(self.repo, "existing-branch")
         self.assertEqual(self.current_branch(), "existing-branch")
 
+    def test_creates_branch_from_detached_head(self):
+        _git("checkout", "--detach", self.initial_sha, cwd=self.repo)
+        ug.ensure_on_branch(self.repo, "from-detached")
+        self.assertEqual(self.current_branch(), "from-detached")
+        self.assertEqual(self.head_sha(), self.initial_sha)
+
 
 class CommitChangesTests(GitRepoTest):
     def test_commits_when_changes_exist(self):

--- a/scripts/update-grammar
+++ b/scripts/update-grammar
@@ -1,4 +1,10 @@
-#!/usr/bin/env python3
+#!/usr/bin/env uv
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "gitpython>=3.1.0",
+# ]
+# ///
 """Update the upstream tree-sitter grammar submodule for a given language.
 
 Steps performed by `main()` in order:
@@ -40,6 +46,9 @@ import tempfile
 from collections.abc import Collection
 from pathlib import Path
 from typing import NoReturn
+
+import git
+from git.exc import GitCommandError
 
 # Length used when abbreviating SHAs in branch names and commit messages.
 # Pinned so the script produces the same output regardless of the user's
@@ -85,21 +94,36 @@ def sanitize_for_branch(name: str) -> str:
     return sanitized
 
 
+class ProcessResult:
+    """Mimics subprocess.CompletedProcess for backwards compatibility."""
+    def __init__(self, args: list[str], returncode: int, stdout: str = "", stderr: str = ""):
+        self.args = args
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
 def run(
     cmd: list[str | Path], cwd: Path,
     *, check: bool = True, capture: bool = False,
-) -> subprocess.CompletedProcess:
-    """Run a subprocess in `cwd`.
+) -> ProcessResult:
+    """Run a command in `cwd`.
 
+    For non-git commands, this runs subprocess. For git commands,
+    this prints the command and delegates to subprocess.
     `capture=True` pipes stdout (read via `.stdout`); otherwise stdout
     is inherited so the user sees output live. `check=False` returns
     on non-zero — inspect `.returncode`.
     """
     print(f"$ {shlex.join(str(c) for c in cmd)}  (in {cwd})", file=sys.stderr)
-    return subprocess.run(
-        cmd, cwd=cwd, check=check, text=True,
+    result = subprocess.run(
+        cmd, cwd=cwd, check=False, text=True,
         stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.PIPE if capture else None,
     )
+    if check and result.returncode != 0:
+        raise GitCommandError(cmd, result.returncode, result.stdout, result.stderr)
+    return ProcessResult(cmd, result.returncode, result.stdout or "", result.stderr or "")
 
 
 def repo_root() -> Path:
@@ -221,11 +245,10 @@ def submodule_path(root: Path, lang: str) -> Path:
 
 
 def short_sha(submodule: Path, sha: str) -> str:
-    """Return `sha` abbreviated to `ABBREV_LEN` chars via `git rev-parse`."""
-    return run(
-        ["git", "rev-parse", f"--short={ABBREV_LEN}", sha],
-        cwd=submodule, capture=True,
-    ).stdout.strip()
+    """Return `sha` abbreviated to `ABBREV_LEN` chars via GitPython."""
+    repo = git.Repo(submodule)
+    abbreviated = repo.git.rev_parse(f"--short={ABBREV_LEN}", sha)
+    return abbreviated.strip()
 
 
 def discover_version_files(root: Path, prefix: str) -> dict[str, Path]:
@@ -323,19 +346,13 @@ def remove_stale_parsers(root: Path, lang: str, list_name: str) -> None:
         path.unlink()
 
 
-def require_clean_worktree(repo: Path) -> None:
-    """Abort if `repo` has pre-existing changes.
-
-    `commit_changes` later does `git add -A`; a dirty tree would sweep
-    in unrelated WIP. `lang/release` enforces this too — failing here
-    is just earlier and clearer.
-    """
-    status = run(
-        ["git", "status", "--porcelain"], cwd=repo, capture=True,
-    ).stdout.strip()
+def require_clean_worktree(repo_path: Path) -> None:
+    """Abort if `repo_path` has pre-existing changes using GitPython."""
+    repo = git.Repo(repo_path)
+    status = repo.git.status("--porcelain").strip()
     if status:
         die(
-            f"working tree at {repo} is not clean. Commit or stash changes "
+            f"working tree at {repo_path} is not clean. Commit or stash changes "
             f"before running update-grammar, or pass --skip-release.\n"
             f"{status}"
         )
@@ -384,91 +401,91 @@ def parse_args(version_choices: Collection[str],
     return parser.parse_args(argv)
 
 
-def is_shallow_repo(repo: Path) -> bool:
-    """Return True if `repo` is a shallow clone.
-
-    Submodules are usually cloned shallow, which leaves arbitrary historical
-    refs unresolvable. `git rev-parse --is-shallow-repository` prints
-    'true'/'false' (available since git 2.15).
-    """
-    return run(
-        ["git", "rev-parse", "--is-shallow-repository"],
-        cwd=repo, capture=True,
-    ).stdout.strip() == "true"
+def is_shallow_repo(repo_path: Path) -> bool:
+    """Return True if `repo_path` is a shallow clone using GitPython."""
+    repo = git.Repo(repo_path)
+    result = repo.git.rev_parse("--is-shallow-repository").strip()
+    return result == "true"
 
 
 def update_submodule(submodule: Path, root: Path, ref: str,
                      fetch: bool) -> tuple[str, str]:
-    """Check out `ref` in the submodule. Returns (old_sha, new_sha)."""
-    old_sha = run(
-        ["git", "rev-parse", "HEAD"], cwd=submodule, capture=True,
-    ).stdout.strip()
+    """Check out `ref` in the submodule using GitPython. Returns (old_sha, new_sha)."""
+    try:
+        repo = git.Repo(submodule)
+        old_sha = repo.head.commit.hexsha
 
-    if fetch:
-        # Convert a shallow submodule clone to a full one so any historical
-        # `ref` (old tags, distant commits) resolves. `--unshallow` errors on
-        # an already-complete repo, so only run it when actually shallow.
-        if is_shallow_repo(submodule):
-            run(["git", "fetch", "origin", "--unshallow"], cwd=submodule)
-        run(["git", "fetch", "--tags", "origin"], cwd=submodule)
+        if fetch:
+            if is_shallow_repo(submodule):
+                repo.remotes.origin.fetch(unshallow=True)
+            repo.remotes.origin.fetch(tags=True)
 
-    new_sha = run(
-        ["git", "rev-parse", ref], cwd=submodule, capture=True,
-    ).stdout.strip()
+        new_sha = repo.git.rev_parse(ref).strip()
 
-    rel = submodule.relative_to(root)
-    print(f"Submodule {rel}: {old_sha} -> {new_sha} ({ref})")
+        rel = submodule.relative_to(root)
+        print(f"Submodule {rel}: {old_sha} -> {new_sha} ({ref})")
 
-    if old_sha == new_sha:
-        print("Already up to date.")
+        if old_sha == new_sha:
+            print("Already up to date.")
+            return old_sha, new_sha
+
+        repo.head.reference = repo.commit(new_sha)
+        repo.head.reset(index=True, working_tree=True)
+
+        # Stage the submodule reference in the parent repo using git add
+        root_repo = git.Repo(root)
+        root_repo.git.add("--", str(rel))
         return old_sha, new_sha
+    except (GitCommandError, ValueError) as e:
+        if isinstance(e, GitCommandError):
+            raise subprocess.CalledProcessError(e.status, e.command, e.stdout, e.stderr) from e
+        else:
+            # ValueError from GitPython when SHA is invalid
+            raise subprocess.CalledProcessError(1, ["git"], str(e), "") from e
 
-    run(["git", "checkout", new_sha], cwd=submodule)
-    run(["git", "add", "--", rel], cwd=root)
-    return old_sha, new_sha
 
+def ensure_on_branch(repo_path: Path, branch: str, *, at: str | None = None) -> None:
+    """Switch `repo_path` to `branch` using GitPython, creating it from HEAD if missing.
 
-def ensure_on_branch(repo: Path, branch: str, *, at: str | None = None) -> None:
-    """Switch `repo` to `branch`, creating it from HEAD if missing.
-
-    With `at`, force-align via `checkout -B` so a stale branch from a
+    With `at`, force-align via checkout so a stale branch from a
     prior run can't move HEAD off the intended commit.
 
     Needed because `git push --recurse-submodules` requires the same
     branch name in the outer repo and each submodule, else it fails with
     `src refspec ... must name a ref`.
     """
+    repo = git.Repo(repo_path)
     if at is not None:
-        run(["git", "checkout", "-B", branch, at], cwd=repo)
+        repo.heads[branch].checkout(force=True) if branch in [h.name for h in repo.heads] else None
+        repo.create_head(branch, at).checkout()
         return
-    current = run(
-        ["git", "branch", "--show-current"], cwd=repo, capture=True,
-    ).stdout.strip()
+
+    current = repo.active_branch.name
     if current == branch:
         return
-    exists = run(
-        ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"],
-        cwd=repo, check=False,
-    ).returncode == 0
-    cmd = ["git", "checkout", branch] if exists else ["git", "checkout", "-b", branch]
-    run(cmd, cwd=repo)
+
+    try:
+        repo.heads[branch].checkout()
+    except IndexError:
+        repo.create_head(branch).checkout()
 
 
 def commit_changes(root: Path, lang: str, old_short: str, new_short: str) -> None:
-    """Stage and commit the update; no-op if nothing changed.
+    """Stage and commit the update using GitPython; no-op if nothing changed.
 
     `git add -A` is safe because this function only runs in the release
     path (no `--skip-release`), and `main()` enforces a clean tree
     up front in that path via `require_clean_worktree`.
     """
-    run(["git", "add", "-A"], cwd=root)
-    if run(
-        ["git", "diff", "--cached", "--quiet"], cwd=root, check=False,
-    ).returncode == 0:
+    repo = git.Repo(root)
+    repo.index.add("*")
+
+    if not repo.index.diff("HEAD"):
         print("No changes to commit.")
         return
+
     message = f"Update tree-sitter-{lang} grammar from {old_short} to {new_short}"
-    run(["git", "commit", "-m", message], cwd=root)
+    repo.index.commit(message)
 
 
 def main() -> int:
@@ -523,9 +540,8 @@ def main() -> int:
 
     if args.skip_release:
         print("Skipping release: would have run " + shlex.join(release_args))
-        dirty = run(
-            ["git", "status", "--porcelain"], cwd=root, capture=True,
-        ).stdout.strip()
+        repo = git.Repo(root)
+        dirty = repo.git.status("--porcelain").strip()
         if dirty:
             print(
                 "\nThe outer repo now has uncommitted changes (submodule "
@@ -549,8 +565,8 @@ def _entrypoint() -> None:
         sys.exit(main())
     except KeyboardInterrupt:
         sys.exit(130)
-    except subprocess.CalledProcessError as exc:
-        die(f"command failed (exit {exc.returncode}): {shlex.join(str(c) for c in exc.cmd)}")
+    except GitCommandError as exc:
+        die(f"git command failed (exit {exc.status}): {shlex.join(str(c) for c in exc.command)}")
 
 
 if __name__ == "__main__":

--- a/scripts/update-grammar
+++ b/scripts/update-grammar
@@ -47,14 +47,8 @@ from collections.abc import Collection
 from pathlib import Path
 from typing import NoReturn
 
-try:
-    import git
-    from git.exc import GitCommandError
-    HAS_GITPYTHON = True
-except ImportError:
-    HAS_GITPYTHON = False
-
-# Length used when abbreviating SHAs in branch names and commit messages.
+import git
+from git.exc import GitCommandError
 # Pinned so the script produces the same output regardless of the user's
 # local `core.abbrev` config.
 ABBREV_LEN = 8
@@ -235,15 +229,9 @@ def submodule_path(root: Path, lang: str) -> Path:
 
 def short_sha(submodule: Path, sha: str) -> str:
     """Return `sha` abbreviated to `ABBREV_LEN` chars."""
-    if HAS_GITPYTHON:
-        repo = git.Repo(submodule)
-        abbreviated = repo.git.rev_parse(f"--short={ABBREV_LEN}", sha)
-        return abbreviated.strip()
-    else:
-        return run(
-            ["git", "rev-parse", f"--short={ABBREV_LEN}", sha],
-            cwd=submodule, capture=True,
-        ).stdout.strip()
+    repo = git.Repo(submodule)
+    abbreviated = repo.git.rev_parse(f"--short={ABBREV_LEN}", sha)
+    return abbreviated.strip()
 
 
 def discover_version_files(root: Path, prefix: str) -> dict[str, Path]:
@@ -281,7 +269,7 @@ def write_sorted_languages_entries(path: Path, entries: set[str]) -> None:
         Path(tmp.name).replace(path)
     except BaseException:
         Path(tmp.name).unlink(missing_ok=True)
-        raise
+
 
 
 def sync_membership(names: list[str], version: str,
@@ -343,27 +331,14 @@ def remove_stale_parsers(root: Path, lang: str, list_name: str) -> None:
 
 def require_clean_worktree(repo_path: Path) -> None:
     """Abort if `repo_path` has pre-existing changes."""
-    if HAS_GITPYTHON:
-        repo = git.Repo(repo_path)
-        if repo.is_dirty(untracked_files=True):
-            status = repo.git.status("--porcelain").strip()
-            die(
-                f"working tree at {repo_path} is not clean. Commit or stash changes "
-                f"before running update-grammar, or pass --skip-release.\n"
-                f"{status}"
-            )
-    else:
-        status = run(
-            ["git", "status", "--porcelain"], cwd=repo_path, capture=True,
-        ).stdout.strip()
-        if status:
-            die(
-                f"working tree at {repo_path} is not clean. Commit or stash changes "
-                f"before running update-grammar, or pass --skip-release.\n"
-                f"{status}"
-            )
-
-
+    repo = git.Repo(repo_path)
+    if repo.is_dirty(untracked_files=True):
+        status = repo.git.status("--porcelain").strip()
+        die(
+            f"working tree at {repo_path} is not clean. Commit or stash changes "
+            f"before running update-grammar, or pass --skip-release.\n"
+            f"{status}"
+        )
 def parse_args(version_choices: Collection[str],
                argv: list[str] | None = None) -> argparse.Namespace:
     """Parse CLI args; `version_choices` constrains the `tree-sitter-version` positional."""
@@ -423,51 +398,16 @@ def is_shallow_repo(repo_path: Path) -> bool:
 def update_submodule(submodule: Path, root: Path, ref: str,
                      fetch: bool) -> tuple[str, str]:
     """Check out `ref` in the submodule. Returns (old_sha, new_sha)."""
-    if HAS_GITPYTHON:
-        try:
-            repo = git.Repo(submodule)
-            old_sha = repo.head.commit.hexsha
-
-            if fetch:
-                if is_shallow_repo(submodule):
-                    repo.remotes.origin.fetch(unshallow=True)
-                repo.remotes.origin.fetch(tags=True)
-
-            new_sha = repo.git.rev_parse(ref).strip()
-
-            rel = submodule.relative_to(root)
-            print(f"Submodule {rel}: {old_sha} -> {new_sha} ({ref})")
-
-            if old_sha == new_sha:
-                print("Already up to date.")
-                return old_sha, new_sha
-
-            repo.head.reference = repo.commit(new_sha)
-            repo.head.reset(index=True, working_tree=True)
-
-            # Stage the submodule reference in the parent repo using git add
-            root_repo = git.Repo(root)
-            root_repo.git.add("--", str(rel))
-            return old_sha, new_sha
-        except (GitCommandError, ValueError) as e:
-            status = e.status if isinstance(e, GitCommandError) else 1
-            cmd = e.command if isinstance(e, GitCommandError) else ["git"]
-            stdout = e.stdout if isinstance(e, GitCommandError) else str(e)
-            raise subprocess.CalledProcessError(status, cmd, stdout, "") from e
-    else:
-        # Fallback to subprocess
-        old_sha = run(
-            ["git", "rev-parse", "HEAD"], cwd=submodule, capture=True,
-        ).stdout.strip()
+    try:
+        repo = git.Repo(submodule)
+        old_sha = repo.head.commit.hexsha
 
         if fetch:
             if is_shallow_repo(submodule):
-                run(["git", "fetch", "origin", "--unshallow"], cwd=submodule)
-            run(["git", "fetch", "--tags", "origin"], cwd=submodule)
+                repo.remotes.origin.fetch(unshallow=True)
+            repo.remotes.origin.fetch(tags=True)
 
-        new_sha = run(
-            ["git", "rev-parse", ref], cwd=submodule, capture=True,
-        ).stdout.strip()
+        new_sha = repo.git.rev_parse(ref).strip()
 
         rel = submodule.relative_to(root)
         print(f"Submodule {rel}: {old_sha} -> {new_sha} ({ref})")
@@ -476,11 +416,18 @@ def update_submodule(submodule: Path, root: Path, ref: str,
             print("Already up to date.")
             return old_sha, new_sha
 
-        run(["git", "checkout", new_sha], cwd=submodule)
-        run(["git", "add", "--", str(rel)], cwd=root)
+        repo.head.reference = repo.commit(new_sha)
+        repo.head.reset(index=True, working_tree=True)
+
+        # Stage the submodule reference in the parent repo using git add
+        root_repo = git.Repo(root)
+        root_repo.git.add("--", str(rel))
         return old_sha, new_sha
-
-
+    except (GitCommandError, ValueError) as e:
+        status = e.status if isinstance(e, GitCommandError) else 1
+        cmd = e.command if isinstance(e, GitCommandError) else ["git"]
+        stdout = e.stdout if isinstance(e, GitCommandError) else str(e)
+        raise subprocess.CalledProcessError(status, cmd, stdout, "") from e
 def ensure_on_branch(repo_path: Path, branch: str, *, at: str | None = None) -> None:
     """Switch `repo_path` to `branch`, creating it from HEAD if missing.
 
@@ -491,41 +438,20 @@ def ensure_on_branch(repo_path: Path, branch: str, *, at: str | None = None) -> 
     branch name in the outer repo and each submodule, else it fails with
     `src refspec ... must name a ref`.
     """
-    if HAS_GITPYTHON:
-        repo = git.Repo(repo_path)
-        if at is not None:
-            # Use git checkout -B to replace the branch if it exists (including current)
-            repo.git.checkout("-B", branch, at)
-            return
+    repo = git.Repo(repo_path)
+    if at is not None:
+        # Use git checkout -B to replace the branch if it exists (including current)
+        repo.git.checkout("-B", branch, at)
+        return
 
-        current = repo.active_branch.name
-        if current == branch:
-            return
+    current = repo.active_branch.name
+    if current == branch:
+        return
 
-        try:
-            repo.heads[branch].checkout()
-        except IndexError:
-            repo.create_head(branch).checkout()
-    else:
-        # Fallback to subprocess
-        if at is not None:
-            run(["git", "checkout", "-B", branch, at], cwd=repo_path)
-            return
-
-        current = run(
-            ["git", "branch", "--show-current"], cwd=repo_path, capture=True
-        ).stdout.strip()
-        if current == branch:
-            return
-
-        exists = run(
-            ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"],
-            cwd=repo_path, check=False,
-        ).returncode == 0
-        cmd = ["git", "checkout", branch] if exists else ["git", "checkout", "-b", branch]
-        run(cmd, cwd=repo_path)
-
-
+    try:
+        repo.heads[branch].checkout()
+    except IndexError:
+        repo.create_head(branch).checkout()
 def commit_changes(root: Path, lang: str, old_short: str, new_short: str) -> None:
     """Stage and commit the update; no-op if nothing changed.
 
@@ -533,28 +459,15 @@ def commit_changes(root: Path, lang: str, old_short: str, new_short: str) -> Non
     path (no `--skip-release`), and `main()` enforces a clean tree
     up front in that path via `require_clean_worktree`.
     """
-    if HAS_GITPYTHON:
-        repo = git.Repo(root)
-        repo.index.add("*", force=True)
+    repo = git.Repo(root)
+    repo.index.add("*", force=True)
 
-        if not repo.index.diff("HEAD"):
-            print("No changes to commit.")
-            return
+    if not repo.index.diff("HEAD"):
+        print("No changes to commit.")
+        return
 
-        message = f"Update tree-sitter-{lang} grammar from {old_short} to {new_short}"
-        repo.index.commit(message)
-    else:
-        # Fallback to subprocess
-        run(["git", "add", "-A"], cwd=root)
-        if run(
-            ["git", "diff", "--cached", "--quiet"], cwd=root, check=False,
-        ).returncode == 0:
-            print("No changes to commit.")
-            return
-        message = f"Update tree-sitter-{lang} grammar from {old_short} to {new_short}"
-        run(["git", "commit", "-m", message], cwd=root)
-
-
+    message = f"Update tree-sitter-{lang} grammar from {old_short} to {new_short}"
+    repo.index.commit(message)
 def main() -> int:
     """Drive the full update flow; see module docstring for the step list."""
     root = repo_root()
@@ -634,11 +547,8 @@ def _entrypoint() -> None:
         sys.exit(130)
     except subprocess.CalledProcessError as exc:
         die(f"command failed (exit {exc.returncode}): {shlex.join(str(c) for c in exc.cmd)}")
-    except Exception as exc:
-        if HAS_GITPYTHON and isinstance(exc, GitCommandError):
-            die(f"git command failed (exit {exc.status}): {shlex.join(str(c) for c in exc.command)}")
-        raise
-
+    except GitCommandError as exc:
+        die(f"git command failed (exit {exc.status}): {shlex.join(str(c) for c in exc.command)}")
 
 if __name__ == "__main__":
     _entrypoint()

--- a/scripts/update-grammar
+++ b/scripts/update-grammar
@@ -269,7 +269,7 @@ def write_sorted_languages_entries(path: Path, entries: set[str]) -> None:
         Path(tmp.name).replace(path)
     except BaseException:
         Path(tmp.name).unlink(missing_ok=True)
-
+        raise
 
 
 def sync_membership(names: list[str], version: str,
@@ -452,6 +452,8 @@ def ensure_on_branch(repo_path: Path, branch: str, *, at: str | None = None) -> 
         repo.heads[branch].checkout()
     except IndexError:
         repo.create_head(branch).checkout()
+
+
 def commit_changes(root: Path, lang: str, old_short: str, new_short: str) -> None:
     """Stage and commit the update; no-op if nothing changed.
 
@@ -460,14 +462,17 @@ def commit_changes(root: Path, lang: str, old_short: str, new_short: str) -> Non
     up front in that path via `require_clean_worktree`.
     """
     repo = git.Repo(root)
-    repo.index.add("*", force=True)
+    # Use CLI `git add -A` so deletions are staged (IndexFile.add does not).
+    repo.git.add(A=True)
 
-    if not repo.index.diff("HEAD"):
+    if not repo.git.diff("--cached"):
         print("No changes to commit.")
         return
 
     message = f"Update tree-sitter-{lang} grammar from {old_short} to {new_short}"
-    repo.index.commit(message)
+    repo.git.commit("-m", message)
+
+
 def main() -> int:
     """Drive the full update flow; see module docstring for the step list."""
     root = repo_root()

--- a/scripts/update-grammar
+++ b/scripts/update-grammar
@@ -94,36 +94,21 @@ def sanitize_for_branch(name: str) -> str:
     return sanitized
 
 
-class ProcessResult:
-    """Mimics subprocess.CompletedProcess for backwards compatibility."""
-    def __init__(self, args: list[str], returncode: int, stdout: str = "", stderr: str = ""):
-        self.args = args
-        self.returncode = returncode
-        self.stdout = stdout
-        self.stderr = stderr
-
-
 def run(
     cmd: list[str | Path], cwd: Path,
     *, check: bool = True, capture: bool = False,
-) -> ProcessResult:
-    """Run a command in `cwd`.
+) -> subprocess.CompletedProcess:
+    """Run a subprocess in `cwd`.
 
-    For non-git commands, this runs subprocess. For git commands,
-    this prints the command and delegates to subprocess.
     `capture=True` pipes stdout (read via `.stdout`); otherwise stdout
     is inherited so the user sees output live. `check=False` returns
     on non-zero — inspect `.returncode`.
     """
     print(f"$ {shlex.join(str(c) for c in cmd)}  (in {cwd})", file=sys.stderr)
-    result = subprocess.run(
-        cmd, cwd=cwd, check=False, text=True,
+    return subprocess.run(
+        cmd, cwd=cwd, check=check, text=True,
         stdout=subprocess.PIPE if capture else None,
-        stderr=subprocess.PIPE if capture else None,
     )
-    if check and result.returncode != 0:
-        raise GitCommandError(cmd, result.returncode, result.stdout, result.stderr)
-    return ProcessResult(cmd, result.returncode, result.stdout or "", result.stderr or "")
 
 
 def repo_root() -> Path:
@@ -245,7 +230,7 @@ def submodule_path(root: Path, lang: str) -> Path:
 
 
 def short_sha(submodule: Path, sha: str) -> str:
-    """Return `sha` abbreviated to `ABBREV_LEN` chars via GitPython."""
+    """Return `sha` abbreviated to `ABBREV_LEN` chars."""
     repo = git.Repo(submodule)
     abbreviated = repo.git.rev_parse(f"--short={ABBREV_LEN}", sha)
     return abbreviated.strip()
@@ -347,10 +332,10 @@ def remove_stale_parsers(root: Path, lang: str, list_name: str) -> None:
 
 
 def require_clean_worktree(repo_path: Path) -> None:
-    """Abort if `repo_path` has pre-existing changes using GitPython."""
+    """Abort if `repo_path` has pre-existing changes."""
     repo = git.Repo(repo_path)
-    status = repo.git.status("--porcelain").strip()
-    if status:
+    if repo.is_dirty(untracked_files=True):
+        status = repo.git.status("--porcelain").strip()
         die(
             f"working tree at {repo_path} is not clean. Commit or stash changes "
             f"before running update-grammar, or pass --skip-release.\n"
@@ -402,15 +387,13 @@ def parse_args(version_choices: Collection[str],
 
 
 def is_shallow_repo(repo_path: Path) -> bool:
-    """Return True if `repo_path` is a shallow clone using GitPython."""
-    repo = git.Repo(repo_path)
-    result = repo.git.rev_parse("--is-shallow-repository").strip()
-    return result == "true"
+    """Return True if `repo_path` is a shallow clone."""
+    return (repo_path / ".git" / "shallow").exists()
 
 
 def update_submodule(submodule: Path, root: Path, ref: str,
                      fetch: bool) -> tuple[str, str]:
-    """Check out `ref` in the submodule using GitPython. Returns (old_sha, new_sha)."""
+    """Check out `ref` in the submodule. Returns (old_sha, new_sha)."""
     try:
         repo = git.Repo(submodule)
         old_sha = repo.head.commit.hexsha
@@ -437,18 +420,17 @@ def update_submodule(submodule: Path, root: Path, ref: str,
         root_repo.git.add("--", str(rel))
         return old_sha, new_sha
     except (GitCommandError, ValueError) as e:
-        if isinstance(e, GitCommandError):
-            raise subprocess.CalledProcessError(e.status, e.command, e.stdout, e.stderr) from e
-        else:
-            # ValueError from GitPython when SHA is invalid
-            raise subprocess.CalledProcessError(1, ["git"], str(e), "") from e
+        status = e.status if isinstance(e, GitCommandError) else 1
+        cmd = e.command if isinstance(e, GitCommandError) else ["git"]
+        stdout = e.stdout if isinstance(e, GitCommandError) else str(e)
+        raise subprocess.CalledProcessError(status, cmd, stdout, "") from e
 
 
 def ensure_on_branch(repo_path: Path, branch: str, *, at: str | None = None) -> None:
-    """Switch `repo_path` to `branch` using GitPython, creating it from HEAD if missing.
+    """Switch `repo_path` to `branch`, creating it from HEAD if missing.
 
-    With `at`, force-align via checkout so a stale branch from a
-    prior run can't move HEAD off the intended commit.
+    With `at`, force-align so a stale branch from a prior run can't move
+    HEAD off the intended commit.
 
     Needed because `git push --recurse-submodules` requires the same
     branch name in the outer repo and each submodule, else it fails with
@@ -456,7 +438,11 @@ def ensure_on_branch(repo_path: Path, branch: str, *, at: str | None = None) -> 
     """
     repo = git.Repo(repo_path)
     if at is not None:
-        repo.heads[branch].checkout(force=True) if branch in [h.name for h in repo.heads] else None
+        # Force-align: delete the branch if it exists, then recreate at the target
+        try:
+            repo.delete_head(branch, force=True)
+        except (IndexError, GitCommandError):
+            pass
         repo.create_head(branch, at).checkout()
         return
 
@@ -471,7 +457,7 @@ def ensure_on_branch(repo_path: Path, branch: str, *, at: str | None = None) -> 
 
 
 def commit_changes(root: Path, lang: str, old_short: str, new_short: str) -> None:
-    """Stage and commit the update using GitPython; no-op if nothing changed.
+    """Stage and commit the update; no-op if nothing changed.
 
     `git add -A` is safe because this function only runs in the release
     path (no `--skip-release`), and `main()` enforces a clean tree

--- a/scripts/update-grammar
+++ b/scripts/update-grammar
@@ -444,7 +444,7 @@ def ensure_on_branch(repo_path: Path, branch: str, *, at: str | None = None) -> 
         repo.git.checkout("-B", branch, at)
         return
 
-    current = repo.active_branch.name
+    current = None if repo.head.is_detached else repo.active_branch.name
     if current == branch:
         return
 

--- a/scripts/update-grammar
+++ b/scripts/update-grammar
@@ -1,4 +1,4 @@
-#!/usr/bin/env uv
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
@@ -47,8 +47,12 @@ from collections.abc import Collection
 from pathlib import Path
 from typing import NoReturn
 
-import git
-from git.exc import GitCommandError
+try:
+    import git
+    from git.exc import GitCommandError
+    HAS_GITPYTHON = True
+except ImportError:
+    HAS_GITPYTHON = False
 
 # Length used when abbreviating SHAs in branch names and commit messages.
 # Pinned so the script produces the same output regardless of the user's
@@ -231,9 +235,15 @@ def submodule_path(root: Path, lang: str) -> Path:
 
 def short_sha(submodule: Path, sha: str) -> str:
     """Return `sha` abbreviated to `ABBREV_LEN` chars."""
-    repo = git.Repo(submodule)
-    abbreviated = repo.git.rev_parse(f"--short={ABBREV_LEN}", sha)
-    return abbreviated.strip()
+    if HAS_GITPYTHON:
+        repo = git.Repo(submodule)
+        abbreviated = repo.git.rev_parse(f"--short={ABBREV_LEN}", sha)
+        return abbreviated.strip()
+    else:
+        return run(
+            ["git", "rev-parse", f"--short={ABBREV_LEN}", sha],
+            cwd=submodule, capture=True,
+        ).stdout.strip()
 
 
 def discover_version_files(root: Path, prefix: str) -> dict[str, Path]:
@@ -333,14 +343,25 @@ def remove_stale_parsers(root: Path, lang: str, list_name: str) -> None:
 
 def require_clean_worktree(repo_path: Path) -> None:
     """Abort if `repo_path` has pre-existing changes."""
-    repo = git.Repo(repo_path)
-    if repo.is_dirty(untracked_files=True):
-        status = repo.git.status("--porcelain").strip()
-        die(
-            f"working tree at {repo_path} is not clean. Commit or stash changes "
-            f"before running update-grammar, or pass --skip-release.\n"
-            f"{status}"
-        )
+    if HAS_GITPYTHON:
+        repo = git.Repo(repo_path)
+        if repo.is_dirty(untracked_files=True):
+            status = repo.git.status("--porcelain").strip()
+            die(
+                f"working tree at {repo_path} is not clean. Commit or stash changes "
+                f"before running update-grammar, or pass --skip-release.\n"
+                f"{status}"
+            )
+    else:
+        status = run(
+            ["git", "status", "--porcelain"], cwd=repo_path, capture=True,
+        ).stdout.strip()
+        if status:
+            die(
+                f"working tree at {repo_path} is not clean. Commit or stash changes "
+                f"before running update-grammar, or pass --skip-release.\n"
+                f"{status}"
+            )
 
 
 def parse_args(version_choices: Collection[str],
@@ -388,22 +409,65 @@ def parse_args(version_choices: Collection[str],
 
 def is_shallow_repo(repo_path: Path) -> bool:
     """Return True if `repo_path` is a shallow clone."""
-    return (repo_path / ".git" / "shallow").exists()
+    git_dir = repo_path / ".git"
+    # Handle submodules where .git is a gitfile, not a directory
+    if git_dir.is_file():
+        # Parse gitfile to find the actual git directory
+        gitfile_content = git_dir.read_text().strip()
+        if gitfile_content.startswith("gitdir: "):
+            git_path = gitfile_content[8:].strip()
+            git_dir = (repo_path / git_path).resolve()
+    return (git_dir / "shallow").exists()
 
 
 def update_submodule(submodule: Path, root: Path, ref: str,
                      fetch: bool) -> tuple[str, str]:
     """Check out `ref` in the submodule. Returns (old_sha, new_sha)."""
-    try:
-        repo = git.Repo(submodule)
-        old_sha = repo.head.commit.hexsha
+    if HAS_GITPYTHON:
+        try:
+            repo = git.Repo(submodule)
+            old_sha = repo.head.commit.hexsha
+
+            if fetch:
+                if is_shallow_repo(submodule):
+                    repo.remotes.origin.fetch(unshallow=True)
+                repo.remotes.origin.fetch(tags=True)
+
+            new_sha = repo.git.rev_parse(ref).strip()
+
+            rel = submodule.relative_to(root)
+            print(f"Submodule {rel}: {old_sha} -> {new_sha} ({ref})")
+
+            if old_sha == new_sha:
+                print("Already up to date.")
+                return old_sha, new_sha
+
+            repo.head.reference = repo.commit(new_sha)
+            repo.head.reset(index=True, working_tree=True)
+
+            # Stage the submodule reference in the parent repo using git add
+            root_repo = git.Repo(root)
+            root_repo.git.add("--", str(rel))
+            return old_sha, new_sha
+        except (GitCommandError, ValueError) as e:
+            status = e.status if isinstance(e, GitCommandError) else 1
+            cmd = e.command if isinstance(e, GitCommandError) else ["git"]
+            stdout = e.stdout if isinstance(e, GitCommandError) else str(e)
+            raise subprocess.CalledProcessError(status, cmd, stdout, "") from e
+    else:
+        # Fallback to subprocess
+        old_sha = run(
+            ["git", "rev-parse", "HEAD"], cwd=submodule, capture=True,
+        ).stdout.strip()
 
         if fetch:
             if is_shallow_repo(submodule):
-                repo.remotes.origin.fetch(unshallow=True)
-            repo.remotes.origin.fetch(tags=True)
+                run(["git", "fetch", "origin", "--unshallow"], cwd=submodule)
+            run(["git", "fetch", "--tags", "origin"], cwd=submodule)
 
-        new_sha = repo.git.rev_parse(ref).strip()
+        new_sha = run(
+            ["git", "rev-parse", ref], cwd=submodule, capture=True,
+        ).stdout.strip()
 
         rel = submodule.relative_to(root)
         print(f"Submodule {rel}: {old_sha} -> {new_sha} ({ref})")
@@ -412,18 +476,9 @@ def update_submodule(submodule: Path, root: Path, ref: str,
             print("Already up to date.")
             return old_sha, new_sha
 
-        repo.head.reference = repo.commit(new_sha)
-        repo.head.reset(index=True, working_tree=True)
-
-        # Stage the submodule reference in the parent repo using git add
-        root_repo = git.Repo(root)
-        root_repo.git.add("--", str(rel))
+        run(["git", "checkout", new_sha], cwd=submodule)
+        run(["git", "add", "--", str(rel)], cwd=root)
         return old_sha, new_sha
-    except (GitCommandError, ValueError) as e:
-        status = e.status if isinstance(e, GitCommandError) else 1
-        cmd = e.command if isinstance(e, GitCommandError) else ["git"]
-        stdout = e.stdout if isinstance(e, GitCommandError) else str(e)
-        raise subprocess.CalledProcessError(status, cmd, stdout, "") from e
 
 
 def ensure_on_branch(repo_path: Path, branch: str, *, at: str | None = None) -> None:
@@ -436,24 +491,39 @@ def ensure_on_branch(repo_path: Path, branch: str, *, at: str | None = None) -> 
     branch name in the outer repo and each submodule, else it fails with
     `src refspec ... must name a ref`.
     """
-    repo = git.Repo(repo_path)
-    if at is not None:
-        # Force-align: delete the branch if it exists, then recreate at the target
+    if HAS_GITPYTHON:
+        repo = git.Repo(repo_path)
+        if at is not None:
+            # Use git checkout -B to replace the branch if it exists (including current)
+            repo.git.checkout("-B", branch, at)
+            return
+
+        current = repo.active_branch.name
+        if current == branch:
+            return
+
         try:
-            repo.delete_head(branch, force=True)
-        except (IndexError, GitCommandError):
-            pass
-        repo.create_head(branch, at).checkout()
-        return
+            repo.heads[branch].checkout()
+        except IndexError:
+            repo.create_head(branch).checkout()
+    else:
+        # Fallback to subprocess
+        if at is not None:
+            run(["git", "checkout", "-B", branch, at], cwd=repo_path)
+            return
 
-    current = repo.active_branch.name
-    if current == branch:
-        return
+        current = run(
+            ["git", "branch", "--show-current"], cwd=repo_path, capture=True
+        ).stdout.strip()
+        if current == branch:
+            return
 
-    try:
-        repo.heads[branch].checkout()
-    except IndexError:
-        repo.create_head(branch).checkout()
+        exists = run(
+            ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"],
+            cwd=repo_path, check=False,
+        ).returncode == 0
+        cmd = ["git", "checkout", branch] if exists else ["git", "checkout", "-b", branch]
+        run(cmd, cwd=repo_path)
 
 
 def commit_changes(root: Path, lang: str, old_short: str, new_short: str) -> None:
@@ -463,15 +533,26 @@ def commit_changes(root: Path, lang: str, old_short: str, new_short: str) -> Non
     path (no `--skip-release`), and `main()` enforces a clean tree
     up front in that path via `require_clean_worktree`.
     """
-    repo = git.Repo(root)
-    repo.index.add("*")
+    if HAS_GITPYTHON:
+        repo = git.Repo(root)
+        repo.index.add("*", force=True)
 
-    if not repo.index.diff("HEAD"):
-        print("No changes to commit.")
-        return
+        if not repo.index.diff("HEAD"):
+            print("No changes to commit.")
+            return
 
-    message = f"Update tree-sitter-{lang} grammar from {old_short} to {new_short}"
-    repo.index.commit(message)
+        message = f"Update tree-sitter-{lang} grammar from {old_short} to {new_short}"
+        repo.index.commit(message)
+    else:
+        # Fallback to subprocess
+        run(["git", "add", "-A"], cwd=root)
+        if run(
+            ["git", "diff", "--cached", "--quiet"], cwd=root, check=False,
+        ).returncode == 0:
+            print("No changes to commit.")
+            return
+        message = f"Update tree-sitter-{lang} grammar from {old_short} to {new_short}"
+        run(["git", "commit", "-m", message], cwd=root)
 
 
 def main() -> int:
@@ -551,8 +632,12 @@ def _entrypoint() -> None:
         sys.exit(main())
     except KeyboardInterrupt:
         sys.exit(130)
-    except GitCommandError as exc:
-        die(f"git command failed (exit {exc.status}): {shlex.join(str(c) for c in exc.command)}")
+    except subprocess.CalledProcessError as exc:
+        die(f"command failed (exit {exc.returncode}): {shlex.join(str(c) for c in exc.cmd)}")
+    except Exception as exc:
+        if HAS_GITPYTHON and isinstance(exc, GitCommandError):
+            die(f"git command failed (exit {exc.status}): {shlex.join(str(c) for c in exc.command)}")
+        raise
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,51 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P1W"
+
+[[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.50"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
+]
+
+[[package]]
+name = "ocaml-tree-sitter-semgrep"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "gitpython" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "gitpython", specifier = ">=3.1.0" }]
+
+[[package]]
+name = "smmap"
+version = "5.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
+]

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,27 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P1W"
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
 name = "gitdb"
 version = "4.0.12"
 source = { registry = "https://pypi.org/simple" }
@@ -31,6 +52,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "ocaml-tree-sitter-semgrep"
 version = "0.1.0"
 source = { virtual = "." }
@@ -38,8 +68,62 @@ dependencies = [
     { name = "gitpython" },
 ]
 
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
-requires-dist = [{ name = "gitpython", specifier = ">=3.1.0" }]
+requires-dist = [
+    { name = "gitpython", specifier = ">=3.1.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8,<9" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
 
 [[package]]
 name = "smmap"
@@ -48,4 +132,67 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
 ]


### PR DESCRIPTION
## Summary

- Run Python scripts/tests via `uv` (`pyproject.toml` + `uv.lock`) instead of ad hoc pip/`python`
- Drive git ops in `update-grammar` / `propose-grammar-update` with GitPython
- Run pre-commit before staging so auto-fixes land before commit; harden `ensure_on_branch` for detached HEAD

## Test plan

- [ ] `make test-python`
- [ ] Spot-check propose workflow jobs still invoke scripts via `uv run`