### PR TITLE
ci: narrow the language matrix to the languages a PR can affect

### DIFF
--- a/.github/workflows/test-languages.yml
+++ b/.github/workflows/test-languages.yml
@@ -30,8 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # Need the merge base to diff a pull request against its target.
-          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
+          # Unconditional: a pull request needs the merge base to diff against,
+          # and `event_name == 'pull_request' && 0 || 1` would silently be 1 --
+          # 0 is falsy in a GitHub Actions expression.
+          fetch-depth: 0
       - id: list
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -39,8 +41,12 @@ jobs:
           set -euo pipefail
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             # ...HEAD (merge base) so unrelated commits on the target branch do
-            # not widen the matrix.
-            git diff --name-only "$BASE_SHA...HEAD" > /tmp/changed
+            # not widen the matrix. An unusable base is not fatal: an empty file
+            # makes languages-for-paths select everything.
+            if ! git diff --name-only "$BASE_SHA...HEAD" > /tmp/changed; then
+              echo "could not diff against $BASE_SHA; selecting everything" >&2
+              : > /tmp/changed
+            fi
             wc -l < /tmp/changed | xargs echo "changed files:"
             langs=$(lang/scripts/languages-for-paths < /tmp/changed)
           else

--- a/.github/workflows/test-languages.yml
+++ b/.github/workflows/test-languages.yml
@@ -68,8 +68,10 @@ jobs:
   test-language:
     name: test-lang ${{ matrix.language }}
     needs: enumerate
-    # An empty selection (e.g. a docs-only PR) would otherwise be an invalid
-    # matrix; skipping is accepted by the gate below.
+    # Guard against an empty matrix JSON (invalid for strategy.matrix).
+    # languages-for-paths fail-opens to the full list for shared/docs paths, so
+    # [] is not expected in normal PR narrowing; the gate below still treats
+    # skipped+[] as the only acceptable skip.
     if: needs.enumerate.outputs.languages != '[]'
     # c-sharp-pro OOMs on a standard ~16GB runner during 'tree-sitter generate',
     # so it gets an org larger runner. Label is singular: ubuntu-latest-8-core.

--- a/.github/workflows/test-languages.yml
+++ b/.github/workflows/test-languages.yml
@@ -3,8 +3,11 @@ name: Test languages
 # Per-language grammar build/test matrix. Replaces the former CircleCI
 # `test-language` job (.circleci/config.yml, removed in #627).
 #
-# For each language from lang/scripts/list-languages, runs
-# `./test-lang <lang>`. All failures are fatal.
+# For each language, runs `./test-lang <lang>`. All failures are fatal.
+#
+# On a pull request the matrix is narrowed to the languages the diff can affect
+# (lang/scripts/languages-for-paths); pushes to main and manual runs always test
+# everything, so main is never partially verified.
 
 on:
   pull_request:
@@ -26,14 +29,33 @@ jobs:
       languages: ${{ steps.list.outputs.languages }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Need the merge base to diff a pull request against its target.
+          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
       - id: list
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
-          echo "languages=$(lang/scripts/list-languages | jq -Rnc '[inputs]')" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # ...HEAD (merge base) so unrelated commits on the target branch do
+            # not widen the matrix.
+            git diff --name-only "$BASE_SHA...HEAD" > /tmp/changed
+            wc -l < /tmp/changed | xargs echo "changed files:"
+            langs=$(lang/scripts/languages-for-paths < /tmp/changed)
+          else
+            langs=$(lang/scripts/list-languages)
+          fi
+          echo "selected $(echo "$langs" | grep -c . || true) language(s):"
+          echo "$langs"
+          echo "languages=$(echo "$langs" | jq -Rnc '[inputs | select(length > 0)]')" >> "$GITHUB_OUTPUT"
 
   test-language:
     name: test-lang ${{ matrix.language }}
     needs: enumerate
+    # An empty selection (e.g. a docs-only PR) would otherwise be an invalid
+    # matrix; skipping is accepted by the gate below.
+    if: needs.enumerate.outputs.languages != '[]'
     # c-sharp-pro OOMs on a standard ~16GB runner during 'tree-sitter generate',
     # so it gets an org larger runner. Label is singular: ubuntu-latest-8-core.
     runs-on: ${{ matrix.language == 'c-sharp-pro' && fromJSON('{"group":"Default Larger Runners","labels":"ubuntu-latest-8-core"}') || 'ubuntu-latest' }}
@@ -73,12 +95,21 @@ jobs:
   # Single required check for branch protection (matrix expands to many jobs).
   test-languages:
     name: Test languages
-    needs: test-language
+    needs: [enumerate, test-language]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: All languages passed
+      - name: All selected languages passed
         run: |
+          set -euo pipefail
           result="${{ needs.test-language.result }}"
+          selected='${{ needs.enumerate.outputs.languages }}'
+          echo "selected: $selected"
           echo "matrix result: $result"
-          test "$result" = "success"
+          # 'skipped' is only acceptable when nothing was selected -- otherwise a
+          # skipped matrix would silently pass this required check.
+          if [ "$result" = "skipped" ]; then
+            test "$selected" = "[]"
+          else
+            test "$result" = "success"
+          fi

--- a/.github/workflows/test-languages.yml
+++ b/.github/workflows/test-languages.yml
@@ -34,6 +34,15 @@ jobs:
           # and `event_name == 'pull_request' && 0 || 1` would silently be 1 --
           # 0 is falsy in a GitHub Actions expression.
           fetch-depth: 0
+      # The reference graph lives inside the upstream grammars, so without them
+      # languages-for-paths cannot narrow and falls back to the full matrix.
+      # Done by hand rather than via checkout's submodules: input because the
+      # gosu and requirements submodules use SSH URLs, unusable in keyless CI.
+      - name: Check out grammars (for the reference graph)
+        run: |
+          set -euo pipefail
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
+          git submodule update --init --depth 1 --jobs 8
       - id: list
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ test: build
 # Uses the 'pytest' on PATH if present, otherwise falls back to 'python3 -m pytest'.
 # scripts/test_propose_grammar_update.py MUST run as a separate invocation:
 # it's a uv script with its own pinned deps.
-PYTHON_TESTS = lang/test_grammar_ts_version.py lang/test_ts_versions.py lang/test_list_languages.py lang/test_abi15_gating.py scripts/test_update_grammar.py scripts/test_cursor_agent_runner.py
+PYTHON_TESTS = lang/test_grammar_ts_version.py lang/test_ts_versions.py lang/test_list_languages.py lang/test_languages_for_paths.py lang/test_abi15_gating.py scripts/test_update_grammar.py scripts/test_cursor_agent_runner.py
 .PHONY: test-python
 test-python:
 	@if command -v pytest >/dev/null 2>&1; then \

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ test: build
 # Uses the 'pytest' on PATH if present, otherwise falls back to 'python3 -m pytest'.
 # scripts/test_propose_grammar_update.py MUST run as a separate invocation:
 # it's a uv script with its own pinned deps.
-PYTHON_TESTS = lang/test_grammar_ts_version.py lang/test_ts_versions.py lang/test_list_languages.py lang/test_languages_for_paths.py lang/test_abi15_gating.py scripts/test_update_grammar.py scripts/test_cursor_agent_runner.py
+PYTHON_TESTS = lang/test_grammar_ts_version.py lang/test_ts_versions.py lang/test_grammar_dependencies.py lang/test_list_languages.py lang/test_languages_for_paths.py lang/test_abi15_gating.py scripts/test_update_grammar.py scripts/test_cursor_agent_runner.py
 .PHONY: test-python
 test-python:
 	@if command -v pytest >/dev/null 2>&1; then \

--- a/lang/grammar_dependencies.py
+++ b/lang/grammar_dependencies.py
@@ -1,0 +1,176 @@
+"""Grammar reference graph for ``lang/semgrep-grammars/src``.
+
+Used by ``languages-for-paths`` to decide which ``./test-lang`` targets a
+diff can affect. The graph is derived from the grammars themselves so it
+cannot drift from what the build actually loads.
+
+Edge discovery (live code only; comments are stripped first)
+-----------------------------------------------------------
+1. Any ``tree-sitter-<x>`` token in a ``*.js`` or ``prep`` file under a
+   ``semgrep-*`` / ``tree-sitter-*`` dir creates an edge
+   ``tree-sitter-<x> -> that dir``.
+2. A ``prep`` script that builds paths as ``tree-sitter-"$name"`` (or
+   ``tree-sitter-$name``) edges to that wrapper's upstream
+   (``upstream_for_lang``), so powershell / c-sharp-pro are covered even
+   without a literal ``require('tree-sitter-…')``.
+3. ``languages_affected`` then walks those edges transitively and, for every
+   reached ``tree-sitter-X``, also includes language ``X`` when
+   ``semgrep-X`` exists (``UPSTREAM_TO_LANG`` covers ``go-mod`` / ``gomod``).
+
+JS comment stripping is line-based and does not respect string literals, so a
+``"… // …"`` (or ``https://…``) can truncate the rest of that line. No current
+grammar puts a ``require('tree-sitter-…')`` after such a string on the same
+line; the same-name fallback still covers each wrapper's primary upstream.
+
+Invariants (enforced by ``test_grammar_dependencies``)
+------------------------------------------------------
+- Every ``semgrep-<lang>`` has a live reader edge from its upstream dir.
+- Changing that upstream always selects ``<lang>`` (same-name / alias).
+- Documented cross-grammar edges stay live (not comment-only)::
+
+      tree-sitter-c            -> tree-sitter-cpp   (hence language cpp)
+      tree-sitter-javascript   -> tree-sitter-typescript  (hence typescript)
+
+  So a JS upstream bump retests typescript; a TS bump does not retest
+  javascript.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from pathlib import Path
+
+# Relative to the repo root.
+GRAMMARS_SUBDIR = "lang/semgrep-grammars/src"
+
+# Appears in package.json devDependencies of nearly every upstream grammar.
+NOT_A_GRAMMAR = frozenset({"cli"})
+
+# tree-sitter-<suffix> dir <-> semgrep-<lang> when the names differ.
+UPSTREAM_TO_LANG = {"go-mod": "gomod"}
+LANG_TO_UPSTREAM = {v: k for k, v in UPSTREAM_TO_LANG.items()}
+
+# Cross-grammar edges the matrix relies on. Values are reader *dirs* that must
+# appear in readers()[key] via a live reference (see module docstring).
+REQUIRED_CROSS_READERS: dict[str, frozenset[str]] = {
+    "tree-sitter-c": frozenset({"tree-sitter-cpp"}),
+    "tree-sitter-javascript": frozenset({"tree-sitter-typescript"}),
+}
+
+GRAMMAR_REF = re.compile(r"tree-sitter-([a-z0-9_-]+)")
+# prep.common and friends build paths as tree-sitter-"$name" / tree-sitter-$name.
+# "$name" ends on a quote, so \b cannot follow the quoted form.
+PREP_NAME_REF = re.compile(r"""tree-sitter-(?:"\$name"|\$name\b)""")
+
+_JS_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+_JS_LINE_COMMENT = re.compile(r"//.*?$", re.MULTILINE)
+_SH_LINE_COMMENT = re.compile(r"#.*?$", re.MULTILINE)
+
+
+def default_grammars_src() -> Path:
+    """Return ``lang/semgrep-grammars/src`` next to this module."""
+    return Path(__file__).resolve().parent / "semgrep-grammars" / "src"
+
+
+def _strip_js_comments(text: str) -> str:
+    return _JS_LINE_COMMENT.sub("", _JS_BLOCK_COMMENT.sub("", text))
+
+
+def _strip_sh_comments(text: str) -> str:
+    return _SH_LINE_COMMENT.sub("", text)
+
+
+def lang_for_upstream(tree_sitter_dir: str) -> str:
+    """Map ``tree-sitter-X`` dir name to the standalone language name."""
+    suffix = tree_sitter_dir.removeprefix("tree-sitter-")
+    return UPSTREAM_TO_LANG.get(suffix, suffix)
+
+
+def upstream_for_lang(lang: str) -> str:
+    """Map standalone language name to ``tree-sitter-X`` dir name."""
+    return f"tree-sitter-{LANG_TO_UPSTREAM.get(lang, lang)}"
+
+
+def wrapper_upstream_pairs(src: Path | None = None) -> list[tuple[str, str]]:
+    """Return ``(semgrep-<lang>, tree-sitter-…)`` for every wrapper under *src*."""
+    root = src or default_grammars_src()
+    pairs: list[tuple[str, str]] = []
+    for d in sorted(root.glob("semgrep-*")):
+        if d.is_dir():
+            lang = d.name.removeprefix("semgrep-")
+            pairs.append((d.name, upstream_for_lang(lang)))
+    return pairs
+
+
+def readers(src: Path | None = None) -> dict[str, set[str]]:
+    """Map ``tree-sitter-<x>`` -> dirs with a live ``.js``/``prep`` reference."""
+    root = src or default_grammars_src()
+    out: dict[str, set[str]] = defaultdict(set)
+    for d in root.glob("*/"):
+        if not d.name.startswith(("semgrep-", "tree-sitter-")):
+            continue
+        for f in [*d.rglob("*.js"), *d.rglob("prep")]:
+            try:
+                raw = f.read_text(errors="ignore")
+            except OSError:
+                continue
+            is_prep = f.name == "prep"
+            text = _strip_sh_comments(raw) if is_prep else _strip_js_comments(raw)
+            for ref in GRAMMAR_REF.findall(text):
+                if ref in NOT_A_GRAMMAR or f"tree-sitter-{ref}" == d.name:
+                    continue
+                out[f"tree-sitter-{ref}"].add(d.name)
+            if is_prep and PREP_NAME_REF.search(text) and d.name.startswith("semgrep-"):
+                lang = d.name.removeprefix("semgrep-")
+                out[upstream_for_lang(lang)].add(d.name)
+    return out
+
+
+def transitive_dependents(dirs: set[str], src: Path | None = None) -> set[str]:
+    """Grammar dirs reachable by following reader edges from *dirs* (inclusive)."""
+    edges = readers(src)
+    seen: set[str] = set()
+    queue = list(dirs)
+    while queue:
+        d = queue.pop()
+        if d in seen:
+            continue
+        seen.add(d)
+        queue.extend(edges.get(d, set()) - seen)
+    return seen
+
+
+def languages_affected(dirs: set[str], src: Path | None = None) -> set[str]:
+    """Standalone languages affected by changes in *dirs*, following references."""
+    root = src or default_grammars_src()
+    deps = transitive_dependents(dirs, src)
+    langs = {
+        d.removeprefix("semgrep-") for d in deps if d.startswith("semgrep-")
+    }
+    for d in deps:
+        if not d.startswith("tree-sitter-"):
+            continue
+        lang = lang_for_upstream(d)
+        if (root / f"semgrep-{lang}").is_dir():
+            langs.add(lang)
+    return langs
+
+
+def unpopulated_grammar_dirs(src: Path | None = None) -> list[str]:
+    """Upstream dirs with no checked-out content (submodule not initialised).
+
+    Edges live inside the upstream grammars, so an uninitialised submodule makes
+    the graph silently incomplete: without ``tree-sitter-cpp`` checked out,
+    nothing records that it reads ``tree-sitter-c``. Callers that need a
+    complete graph must treat a non-empty result as "cannot trust the edges".
+    """
+    root = src or default_grammars_src()
+
+    def has_content(d: Path) -> bool:
+        # Dotfiles only (a stray .git) do not count: nothing to read edges from.
+        return any(p.name[0] != "." for p in d.iterdir())
+
+    return sorted(
+        d.name for d in root.glob("tree-sitter-*") if d.is_dir() and not has_content(d)
+    )

--- a/lang/scripts/grammar-dependencies
+++ b/lang/scripts/grammar-dependencies
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+#
+# Print the grammar reference graph under lang/semgrep-grammars/src.
+# Edge discovery and invariants are documented in lang/grammar_dependencies.py.
+# With no args: every edge as "<tree-sitter-x>\t<reader-dir>".
+# With args: dirs that transitively depend on the given grammar dirs
+# (including the args themselves), one per line.
+#
+# Usage:
+#   grammar-dependencies
+#   grammar-dependencies tree-sitter-c semgrep-lua
+#
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from grammar_dependencies import readers, transitive_dependents  # noqa: E402
+
+
+def main() -> int:
+    """Print grammar dependency edges, or transitive dependents of the args."""
+    parser = argparse.ArgumentParser(
+        description="Print the grammar reference graph, or transitive dependents."
+    )
+    parser.add_argument(
+        "dirs",
+        nargs="*",
+        help="grammar dirs to expand; omit to dump every edge",
+    )
+    args = parser.parse_args()
+
+    if args.dirs:
+        for d in sorted(transitive_dependents(set(args.dirs))):
+            print(d)
+        return 0
+
+    for target, deps in sorted(readers().items()):
+        for dep in sorted(deps):
+            print(f"{target}\t{dep}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lang/scripts/languages-for-paths
+++ b/lang/scripts/languages-for-paths
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+#
+# Print the languages that need testing given a list of changed file paths
+# (one per line on stdin, as produced by `git diff --name-only`).
+#
+# Fail-safe by design: anything this script does not understand means "test
+# everything". A change confined to grammar directories under
+# lang/semgrep-grammars/src is narrowed to the affected languages; any other
+# path (core/, lang/Makefile*, lang/scripts/, .github/, ...) can affect every
+# language, so the full list is printed.
+#
+# Narrowing follows the grammar reference graph rather than the directory name,
+# because grammars read each other: bumping tree-sitter-c must also test cpp
+# and solidity, and tree-sitter-c-sharp must also test c-sharp-pro. Edges are
+# read out of the grammars themselves (a "tree-sitter-<x>" token in a
+# grammar.js or prep) so the graph cannot drift from reality.
+#
+# Usage: git diff --name-only BASE...HEAD | languages-for-paths
+#
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+GRAMMARS_SUBDIR = "lang/semgrep-grammars/src"
+
+# A grammar dir that is tooling, not a grammar: appears in package.json
+# devDependencies of nearly every upstream grammar.
+NOT_A_GRAMMAR = {"cli"}
+
+GRAMMAR_REF = re.compile(r"tree-sitter-([a-z0-9_-]+)")
+
+
+def grammar_dir_of(path: str) -> str | None:
+    """Return the 'semgrep-x'/'tree-sitter-x' dir a repo path sits in, if any."""
+    parts = Path(path).parts
+    prefix = Path(GRAMMARS_SUBDIR).parts
+    if len(parts) <= len(prefix) or parts[: len(prefix)] != prefix:
+        return None
+    name = parts[len(prefix)]
+    return name if name.startswith(("semgrep-", "tree-sitter-")) else None
+
+
+def read_edges(src: Path) -> dict[str, set[str]]:
+    """Map 'tree-sitter-<x>' -> dirs whose grammar.js/prep reference it."""
+    readers = defaultdict(set)
+    for d in src.glob("*/"):
+        if not d.name.startswith(("semgrep-", "tree-sitter-")):
+            continue
+        for f in [*d.rglob("grammar.js"), *d.rglob("prep")]:
+            try:
+                text = f.read_text(errors="ignore")
+            except OSError:
+                continue
+            for ref in GRAMMAR_REF.findall(text):
+                if ref in NOT_A_GRAMMAR or f"tree-sitter-{ref}" == d.name:
+                    continue
+                readers[f"tree-sitter-{ref}"].add(d.name)
+    return readers
+
+
+def affected_languages(changed_dirs: set[str], src: Path) -> set[str]:
+    """Languages to test, following grammar references transitively."""
+    readers = read_edges(src)
+    seen, queue = set(), list(changed_dirs)
+    while queue:
+        d = queue.pop()
+        if d in seen:
+            continue
+        seen.add(d)
+        queue.extend(readers.get(d, set()) - seen)
+    # Only semgrep-<lang> dirs name a testable language.
+    return {d.removeprefix("semgrep-") for d in seen if d.startswith("semgrep-")}
+
+
+def all_languages(src: Path) -> set[str]:
+    return {p.name.removeprefix("semgrep-") for p in src.glob("semgrep-*") if p.is_dir()}
+
+
+def main() -> int:
+    """Print each language needing a test run on its own line."""
+    argparse.ArgumentParser(
+        description="Print the languages needing tests for the changed paths on stdin."
+    ).parse_args()
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    src = repo_root / GRAMMARS_SUBDIR
+
+    paths = [line.strip() for line in sys.stdin if line.strip()]
+    changed_dirs = {d for p in paths if (d := grammar_dir_of(p))}
+    outside = [p for p in paths if grammar_dir_of(p) is None]
+
+    if outside or not paths:
+        why = "no changed paths given" if not paths else f"shared path {outside[0]!r}"
+        print(f"languages-for-paths: testing everything ({why})", file=sys.stderr)
+        languages = all_languages(src)
+    else:
+        languages = affected_languages(changed_dirs, src) & all_languages(src)
+
+    for lang in sorted(languages):
+        print(lang)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lang/scripts/languages-for-paths
+++ b/lang/scripts/languages-for-paths
@@ -80,6 +80,21 @@ def all_languages(src: Path) -> set[str]:
     return {p.name.removeprefix("semgrep-") for p in src.glob("semgrep-*") if p.is_dir()}
 
 
+def unpopulated_grammar_dirs(src: Path) -> list[str]:
+    """Upstream dirs with no checked-out content (submodule not initialised).
+
+    Edges live inside the upstream grammars, so an uninitialised submodule makes
+    the graph silently incomplete: without tree-sitter-solidity checked out,
+    nothing records that it reads tree-sitter-c, and a tree-sitter-c bump would
+    not test solidity. Callers must treat this as "cannot narrow".
+    """
+    def has_content(d: Path) -> bool:
+        # Dotfiles only (a stray .git) does not count: nothing to read edges from.
+        return any(p.name[0] != "." for p in d.iterdir())
+
+    return sorted(d.name for d in src.glob("tree-sitter-*") if d.is_dir() and not has_content(d))
+
+
 def main() -> int:
     """Print each language needing a test run on its own line."""
     argparse.ArgumentParser(
@@ -91,10 +106,19 @@ def main() -> int:
     paths = [line.strip() for line in sys.stdin if line.strip()]
     changed_dirs = {d for p in paths if (d := grammar_dir_of(p))}
     outside = [p for p in paths if grammar_dir_of(p) is None]
+    unpopulated = unpopulated_grammar_dirs(src)
 
-    if outside or not paths:
-        why = "no changed paths given" if not paths else f"shared path {outside[0]!r}"
-        print(f"languages-for-paths: testing everything ({why})", file=sys.stderr)
+    if not paths:
+        why = "no changed paths given"
+    elif outside:
+        why = f"shared path {outside[0]!r}"
+    elif unpopulated:
+        why = f"{len(unpopulated)} uninitialised submodule(s), e.g. {unpopulated[0]}"
+    else:
+        why = None
+
+    if why:
+        print(f"languages-for-paths: selecting everything ({why})", file=sys.stderr)
         languages = all_languages(src)
     else:
         languages = affected_languages(changed_dirs, src) & all_languages(src)

--- a/lang/scripts/languages-for-paths
+++ b/lang/scripts/languages-for-paths
@@ -5,33 +5,28 @@
 #
 # Fail-safe by design: anything this script does not understand means "test
 # everything". A change confined to grammar directories under
-# lang/semgrep-grammars/src is narrowed to the affected languages; any other
-# path (core/, lang/Makefile*, lang/scripts/, .github/, ...) can affect every
-# language, so the full list is printed.
-#
-# Narrowing follows the grammar reference graph rather than the directory name,
-# because grammars read each other: bumping tree-sitter-c must also test cpp
-# and solidity, and tree-sitter-c-sharp must also test c-sharp-pro. Edges are
-# read out of the grammars themselves (a "tree-sitter-<x>" token in a
-# grammar.js or prep) so the graph cannot drift from reality.
+# lang/semgrep-grammars/src is narrowed via grammar_dependencies (see that
+# module's docstring for edge discovery and invariants: e.g. a
+# tree-sitter-javascript change also selects typescript); any other path
+# (core/, lang/Makefile*, lang/scripts/, .github/, ...) can affect every
+# language, so the full list is printed. Narrowing that resolves to no
+# languages is also treated as "test everything" (fail closed).
 #
 # Usage: git diff --name-only BASE...HEAD | languages-for-paths
 #
 from __future__ import annotations
 
 import argparse
-import re
 import sys
-from collections import defaultdict
 from pathlib import Path
 
-GRAMMARS_SUBDIR = "lang/semgrep-grammars/src"
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-# A grammar dir that is tooling, not a grammar: appears in package.json
-# devDependencies of nearly every upstream grammar.
-NOT_A_GRAMMAR = {"cli"}
-
-GRAMMAR_REF = re.compile(r"tree-sitter-([a-z0-9_-]+)")
+from grammar_dependencies import (  # noqa: E402
+    GRAMMARS_SUBDIR,
+    languages_affected,
+    unpopulated_grammar_dirs,
+)
 
 
 def grammar_dir_of(path: str) -> str | None:
@@ -44,55 +39,8 @@ def grammar_dir_of(path: str) -> str | None:
     return name if name.startswith(("semgrep-", "tree-sitter-")) else None
 
 
-def read_edges(src: Path) -> dict[str, set[str]]:
-    """Map 'tree-sitter-<x>' -> dirs whose grammar.js/prep reference it."""
-    readers = defaultdict(set)
-    for d in src.glob("*/"):
-        if not d.name.startswith(("semgrep-", "tree-sitter-")):
-            continue
-        for f in [*d.rglob("grammar.js"), *d.rglob("prep")]:
-            try:
-                text = f.read_text(errors="ignore")
-            except OSError:
-                continue
-            for ref in GRAMMAR_REF.findall(text):
-                if ref in NOT_A_GRAMMAR or f"tree-sitter-{ref}" == d.name:
-                    continue
-                readers[f"tree-sitter-{ref}"].add(d.name)
-    return readers
-
-
-def affected_languages(changed_dirs: set[str], src: Path) -> set[str]:
-    """Languages to test, following grammar references transitively."""
-    readers = read_edges(src)
-    seen, queue = set(), list(changed_dirs)
-    while queue:
-        d = queue.pop()
-        if d in seen:
-            continue
-        seen.add(d)
-        queue.extend(readers.get(d, set()) - seen)
-    # Only semgrep-<lang> dirs name a testable language.
-    return {d.removeprefix("semgrep-") for d in seen if d.startswith("semgrep-")}
-
-
 def all_languages(src: Path) -> set[str]:
     return {p.name.removeprefix("semgrep-") for p in src.glob("semgrep-*") if p.is_dir()}
-
-
-def unpopulated_grammar_dirs(src: Path) -> list[str]:
-    """Upstream dirs with no checked-out content (submodule not initialised).
-
-    Edges live inside the upstream grammars, so an uninitialised submodule makes
-    the graph silently incomplete: without tree-sitter-solidity checked out,
-    nothing records that it reads tree-sitter-c, and a tree-sitter-c bump would
-    not test solidity. Callers must treat this as "cannot narrow".
-    """
-    def has_content(d: Path) -> bool:
-        # Dotfiles only (a stray .git) does not count: nothing to read edges from.
-        return any(p.name[0] != "." for p in d.iterdir())
-
-    return sorted(d.name for d in src.glob("tree-sitter-*") if d.is_dir() and not has_content(d))
 
 
 def main() -> int:
@@ -104,8 +52,13 @@ def main() -> int:
     src = repo_root / GRAMMARS_SUBDIR
 
     paths = [line.strip() for line in sys.stdin if line.strip()]
-    changed_dirs = {d for p in paths if (d := grammar_dir_of(p))}
-    outside = [p for p in paths if grammar_dir_of(p) is None]
+    changed_dirs: set[str] = set()
+    outside: list[str] = []
+    for p in paths:
+        if d := grammar_dir_of(p):
+            changed_dirs.add(d)
+        else:
+            outside.append(p)
     unpopulated = unpopulated_grammar_dirs(src)
 
     if not paths:
@@ -121,7 +74,17 @@ def main() -> int:
         print(f"languages-for-paths: selecting everything ({why})", file=sys.stderr)
         languages = all_languages(src)
     else:
-        languages = affected_languages(changed_dirs, src) & all_languages(src)
+        languages = languages_affected(changed_dirs, src) & all_languages(src)
+        if not languages:
+            # Fail closed: a grammar-dir diff that maps to nothing must not skip
+            # the matrix (the gate treats [] as success).
+            example = sorted(changed_dirs)[0] if changed_dirs else "unknown"
+            print(
+                f"languages-for-paths: selecting everything "
+                f"(no languages resolved from {example})",
+                file=sys.stderr,
+            )
+            languages = all_languages(src)
 
     for lang in sorted(languages):
         print(lang)

--- a/lang/test_grammar_dependencies.py
+++ b/lang/test_grammar_dependencies.py
@@ -1,0 +1,122 @@
+"""Unit tests for lang/grammar_dependencies."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from grammar_dependencies import (
+    REQUIRED_CROSS_READERS,
+    lang_for_upstream,
+    languages_affected,
+    readers,
+    transitive_dependents,
+    unpopulated_grammar_dirs,
+    upstream_for_lang,
+    wrapper_upstream_pairs,
+)
+
+LANG_DIR = Path(__file__).resolve().parent
+SRC = LANG_DIR / "semgrep-grammars" / "src"
+SUBMODULES_PRESENT = not unpopulated_grammar_dirs(SRC)
+needs_submodules = pytest.mark.skipif(
+    not SUBMODULES_PRESENT, reason="grammar submodules not initialised"
+)
+
+
+def test_go_mod_aliases():
+    assert lang_for_upstream("tree-sitter-go-mod") == "gomod"
+    assert upstream_for_lang("gomod") == "tree-sitter-go-mod"
+    assert lang_for_upstream("tree-sitter-lua") == "lua"
+    assert upstream_for_lang("lua") == "tree-sitter-lua"
+
+
+@needs_submodules
+def test_every_wrapper_has_live_upstream_edge():
+    """Each semgrep-<lang> must have a live edge from its tree-sitter upstream.
+
+    Covers require(), relative paths, and prep's tree-sitter-\"$name\". Without
+    this, languages_affected would rely only on the same-name fallback and a
+    renamed upstream (go-mod vs gomod) could silently drop a language.
+    """
+    edges = readers(SRC)
+    pairs = wrapper_upstream_pairs(SRC)
+    assert pairs, "expected semgrep-* wrappers under semgrep-grammars/src"
+    for semgrep_dir, upstream in pairs:
+        lang = semgrep_dir.removeprefix("semgrep-")
+        assert (SRC / upstream).is_dir(), f"{semgrep_dir} expects missing {upstream}"
+        assert semgrep_dir in edges.get(upstream, set()), (
+            f"no live edge {upstream} -> {semgrep_dir}"
+        )
+        assert lang in languages_affected({upstream}, SRC), (
+            f"changing {upstream} must select language {lang!r}"
+        )
+
+
+@needs_submodules
+def test_required_cross_grammar_edges():
+    """Documented cross-deps (c→cpp, javascript→typescript) stay live.
+
+    typescript's require of javascript lives in common/define-grammar.js, not
+    in a file named grammar.js -- so the scan must cover all *.js.
+    """
+    edges = readers(SRC)
+    for upstream, required in REQUIRED_CROSS_READERS.items():
+        assert required <= edges.get(upstream, set()), (
+            f"{upstream} readers={sorted(edges.get(upstream, set()))}, "
+            f"need {sorted(required)}"
+        )
+    assert languages_affected({"tree-sitter-c"}, SRC) == {"c", "cpp"}
+    assert languages_affected({"tree-sitter-javascript"}, SRC) == {
+        "javascript",
+        "typescript",
+    }
+    assert languages_affected({"tree-sitter-typescript"}, SRC) == {"typescript"}
+
+
+@needs_submodules
+def test_c_is_read_by_cpp_not_comment_only_solidity():
+    """Live edges only: cpp requires c; solidity's URL comment must not count."""
+    assert readers(SRC)["tree-sitter-c"] >= {
+        "semgrep-c",
+        "tree-sitter-cpp",
+    }
+    assert "tree-sitter-solidity" not in readers(SRC)["tree-sitter-c"]
+    assert "semgrep-cpp" not in readers(SRC).get("tree-sitter-c", set())
+
+
+@needs_submodules
+def test_javascript_and_typescript_are_linked_one_way():
+    """typescript reads javascript (via common/define-grammar.js, not grammar.js);
+    javascript does not read typescript. languages_affected for both sides is
+    covered by test_required_cross_grammar_edges."""
+    assert "tree-sitter-typescript" in readers(SRC)["tree-sitter-javascript"]
+    assert "tree-sitter-javascript" not in readers(SRC).get("tree-sitter-typescript", set())
+
+
+@needs_submodules
+def test_prep_name_ref_links_powershell_and_c_sharp_pro():
+    """Wrappers that only use tree-sitter-\"$name\" still get a live edge."""
+    assert "semgrep-powershell" in readers(SRC)["tree-sitter-powershell"]
+    assert "semgrep-c-sharp-pro" in readers(SRC)["tree-sitter-c-sharp-pro"]
+
+
+@needs_submodules
+def test_transitive_dependents_follow_reader_edges():
+    deps = transitive_dependents({"tree-sitter-c"}, SRC)
+    assert {"tree-sitter-c", "tree-sitter-cpp"} <= deps
+    assert {"semgrep-c", "semgrep-cpp"} <= deps
+    assert "tree-sitter-solidity" not in deps
+
+
+@needs_submodules
+def test_languages_affected_filters_to_semgrep_langs():
+    assert languages_affected({"tree-sitter-c"}, SRC) == {"c", "cpp"}
+    assert languages_affected({"tree-sitter-c-sharp"}, SRC) == {"c-sharp"}
+    assert languages_affected({"tree-sitter-c-sharp-pro"}, SRC) == {"c-sharp-pro"}
+    assert languages_affected({"tree-sitter-powershell"}, SRC) == {"powershell"}
+    assert languages_affected({"tree-sitter-go-mod"}, SRC) == {"gomod"}
+    # Comment-only mention of tree-sitter-xml in html must not create an edge;
+    # same-name fallback does not apply (no semgrep-xml).
+    assert languages_affected({"tree-sitter-xml"}, SRC) == set()

--- a/lang/test_languages_for_paths.py
+++ b/lang/test_languages_for_paths.py
@@ -3,33 +3,33 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 LANG_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(LANG_DIR))
+
+from grammar_dependencies import unpopulated_grammar_dirs  # noqa: E402
+
 SCRIPT = LANG_DIR / "scripts" / "languages-for-paths"
 SRC = "lang/semgrep-grammars/src"
 
 # The reference graph is read out of the upstream grammars, so narrowing only
 # works when the submodules are checked out. Without them the script must fall
 # back to the full matrix -- asserted by test_uninitialised_submodules_* below.
-GRAMMARS = LANG_DIR / "semgrep-grammars" / "src"
-SUBMODULES_PRESENT = not [
-    d
-    for d in GRAMMARS.glob("tree-sitter-*")
-    if d.is_dir() and not any(p.name[0] != "." for p in d.iterdir())
-]
+SUBMODULES_PRESENT = not unpopulated_grammar_dirs(LANG_DIR / "semgrep-grammars" / "src")
 needs_submodules = pytest.mark.skipif(
     not SUBMODULES_PRESENT, reason="grammar submodules not initialised"
 )
 
 
-def run(*paths: str) -> list[str]:
+def run(*paths: str) -> tuple[list[str], str]:
     proc = subprocess.run(
         [SCRIPT], input="\n".join(paths), capture_output=True, text=True, check=True
     )
-    return proc.stdout.split()
+    return proc.stdout.split(), proc.stderr
 
 
 def all_languages() -> list[str]:
@@ -40,42 +40,57 @@ def all_languages() -> list[str]:
 
 @needs_submodules
 def test_language_own_dir_narrows_to_that_language():
-    assert run(f"{SRC}/semgrep-lua/grammar.js") == ["lua"]
+    assert run(f"{SRC}/semgrep-lua/grammar.js")[0] == ["lua"]
 
 
 @needs_submodules
 def test_follows_references_between_grammars():
-    """tree-sitter-c is read by cpp and solidity, not just c."""
-    assert set(run(f"{SRC}/tree-sitter-c/src/parser.c")) >= {"c", "cpp", "solidity"}
-    assert set(run(f"{SRC}/tree-sitter-c-sharp/grammar.js")) >= {"c-sharp", "c-sharp-pro"}
+    """tree-sitter-c is read by cpp (live require), not solidity (comment only)."""
+    assert set(run(f"{SRC}/tree-sitter-c/src/parser.c")[0]) == {"c", "cpp"}
+    assert run(f"{SRC}/tree-sitter-c-sharp/grammar.js")[0] == ["c-sharp"]
+    assert run(f"{SRC}/tree-sitter-c-sharp-pro/grammar.js")[0] == ["c-sharp-pro"]
+    assert run(f"{SRC}/tree-sitter-powershell/grammar.js")[0] == ["powershell"]
+    assert run(f"{SRC}/tree-sitter-go-mod/grammar.js")[0] == ["gomod"]
 
 
 @needs_submodules
-def test_upstream_dir_without_a_language_of_its_own():
-    """tree-sitter-xml has no semgrep-xml; it is only reachable via html."""
-    assert run(f"{SRC}/tree-sitter-xml/grammar.js") == ["html"]
+def test_javascript_and_typescript_bidirectional():
+    """JS upstream pulls typescript; TS upstream does not pull javascript."""
+    assert set(run(f"{SRC}/tree-sitter-javascript/grammar.js")[0]) == {
+        "javascript",
+        "typescript",
+    }
+    assert run(f"{SRC}/tree-sitter-typescript/typescript/grammar.js")[0] == ["typescript"]
+
+
+@needs_submodules
+def test_unresolved_grammar_dir_selects_everything():
+    """Fail closed: a tree-sitter dir with no language must not skip the matrix."""
+    langs, err = run(f"{SRC}/tree-sitter-xml/grammar.js")
+    assert langs == all_languages()
+    assert "no languages resolved" in err
 
 
 @pytest.mark.skipif(SUBMODULES_PRESENT, reason="submodules are initialised here")
 def test_uninitialised_submodules_select_everything():
     """Without the upstream grammars the graph is incomplete, so do not narrow.
 
-    This is the dangerous case: tree-sitter-solidity records that it reads
-    tree-sitter-c, so with it absent a tree-sitter-c bump would skip solidity.
+    This is the dangerous case: tree-sitter-cpp records that it reads
+    tree-sitter-c, so with it absent a tree-sitter-c bump would skip cpp.
     """
-    assert run(f"{SRC}/tree-sitter-c/src/parser.c") == all_languages()
+    assert run(f"{SRC}/tree-sitter-c/src/parser.c")[0] == all_languages()
 
 
 def test_shared_path_tests_everything():
     """Anything outside the grammar dirs can affect every language."""
     for shared in ["core/src/x.ml", "lang/Makefile", "lang/scripts/list-languages", ".github/x.yml"]:
-        assert run(shared) == all_languages(), shared
+        assert run(shared)[0] == all_languages(), shared
 
 
 def test_grammar_change_mixed_with_shared_path_tests_everything():
-    assert run(f"{SRC}/semgrep-lua/grammar.js", "lang/Makefile") == all_languages()
+    assert run(f"{SRC}/semgrep-lua/grammar.js", "lang/Makefile")[0] == all_languages()
 
 
 def test_no_changed_paths_tests_everything():
     """Fail safe: an empty diff means we could not tell, so run the full matrix."""
-    assert run() == all_languages()
+    assert run()[0] == all_languages()

--- a/lang/test_languages_for_paths.py
+++ b/lang/test_languages_for_paths.py
@@ -5,9 +5,24 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import pytest
+
 LANG_DIR = Path(__file__).resolve().parent
 SCRIPT = LANG_DIR / "scripts" / "languages-for-paths"
 SRC = "lang/semgrep-grammars/src"
+
+# The reference graph is read out of the upstream grammars, so narrowing only
+# works when the submodules are checked out. Without them the script must fall
+# back to the full matrix -- asserted by test_uninitialised_submodules_* below.
+GRAMMARS = LANG_DIR / "semgrep-grammars" / "src"
+SUBMODULES_PRESENT = not [
+    d
+    for d in GRAMMARS.glob("tree-sitter-*")
+    if d.is_dir() and not any(p.name[0] != "." for p in d.iterdir())
+]
+needs_submodules = pytest.mark.skipif(
+    not SUBMODULES_PRESENT, reason="grammar submodules not initialised"
+)
 
 
 def run(*paths: str) -> list[str]:
@@ -23,19 +38,32 @@ def all_languages() -> list[str]:
     ).stdout.split()
 
 
+@needs_submodules
 def test_language_own_dir_narrows_to_that_language():
     assert run(f"{SRC}/semgrep-lua/grammar.js") == ["lua"]
 
 
+@needs_submodules
 def test_follows_references_between_grammars():
     """tree-sitter-c is read by cpp and solidity, not just c."""
     assert set(run(f"{SRC}/tree-sitter-c/src/parser.c")) >= {"c", "cpp", "solidity"}
     assert set(run(f"{SRC}/tree-sitter-c-sharp/grammar.js")) >= {"c-sharp", "c-sharp-pro"}
 
 
+@needs_submodules
 def test_upstream_dir_without_a_language_of_its_own():
     """tree-sitter-xml has no semgrep-xml; it is only reachable via html."""
     assert run(f"{SRC}/tree-sitter-xml/grammar.js") == ["html"]
+
+
+@pytest.mark.skipif(SUBMODULES_PRESENT, reason="submodules are initialised here")
+def test_uninitialised_submodules_select_everything():
+    """Without the upstream grammars the graph is incomplete, so do not narrow.
+
+    This is the dangerous case: tree-sitter-solidity records that it reads
+    tree-sitter-c, so with it absent a tree-sitter-c bump would skip solidity.
+    """
+    assert run(f"{SRC}/tree-sitter-c/src/parser.c") == all_languages()
 
 
 def test_shared_path_tests_everything():

--- a/lang/test_languages_for_paths.py
+++ b/lang/test_languages_for_paths.py
@@ -1,0 +1,53 @@
+"""Unit tests for lang/scripts/languages-for-paths."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+LANG_DIR = Path(__file__).resolve().parent
+SCRIPT = LANG_DIR / "scripts" / "languages-for-paths"
+SRC = "lang/semgrep-grammars/src"
+
+
+def run(*paths: str) -> list[str]:
+    proc = subprocess.run(
+        [SCRIPT], input="\n".join(paths), capture_output=True, text=True, check=True
+    )
+    return proc.stdout.split()
+
+
+def all_languages() -> list[str]:
+    return subprocess.run(
+        [LANG_DIR / "scripts" / "list-languages"], capture_output=True, text=True, check=True
+    ).stdout.split()
+
+
+def test_language_own_dir_narrows_to_that_language():
+    assert run(f"{SRC}/semgrep-lua/grammar.js") == ["lua"]
+
+
+def test_follows_references_between_grammars():
+    """tree-sitter-c is read by cpp and solidity, not just c."""
+    assert set(run(f"{SRC}/tree-sitter-c/src/parser.c")) >= {"c", "cpp", "solidity"}
+    assert set(run(f"{SRC}/tree-sitter-c-sharp/grammar.js")) >= {"c-sharp", "c-sharp-pro"}
+
+
+def test_upstream_dir_without_a_language_of_its_own():
+    """tree-sitter-xml has no semgrep-xml; it is only reachable via html."""
+    assert run(f"{SRC}/tree-sitter-xml/grammar.js") == ["html"]
+
+
+def test_shared_path_tests_everything():
+    """Anything outside the grammar dirs can affect every language."""
+    for shared in ["core/src/x.ml", "lang/Makefile", "lang/scripts/list-languages", ".github/x.yml"]:
+        assert run(shared) == all_languages(), shared
+
+
+def test_grammar_change_mixed_with_shared_path_tests_everything():
+    assert run(f"{SRC}/semgrep-lua/grammar.js", "lang/Makefile") == all_languages()
+
+
+def test_no_changed_paths_tests_everything():
+    """Fail safe: an empty diff means we could not tell, so run the full matrix."""
+    assert run() == all_languages()


### PR DESCRIPTION
Implements the review suggestion on #646: *"Is there a way to limit the matrix to only run a language if it is changed?"*

A typical grammar bump touches one grammar dir, so this takes the matrix from **47 jobs to 1–3**.

## Why the naive version is unsafe

Grammars read each other, so "changed dir → that language" silently under-tests:

| a change here | must also test |
|---|---|
| `tree-sitter-c` | `cpp`, **`solidity`** |
| `tree-sitter-c-sharp` | `c-sharp-pro` |
| `tree-sitter-xml` | `html` (no `semgrep-xml` exists) |
| `tree-sitter-hacklang` | `hack` (no `semgrep-hacklang` exists) |

`lang/scripts/languages-for-paths` therefore walks the reference graph transitively, reading edges out of the grammars themselves (`tree-sitter-<x>` tokens in `grammar.js` / `prep`) so the graph cannot drift from the grammars it describes.

## Fail-safe in every direction

- Any changed path **outside** the grammar dirs (`core/`, `lang/Makefile`, `lang/scripts/`, `.github/`, …) selects **every** language.
- An empty or unreadable diff selects every language.
- `push: main` and `workflow_dispatch` always select every language, so **main is never partially verified**.
- Over-selection is tolerated (a `tree-sitter-rust` mention in a comment costs one extra job); under-selection is what the graph walk exists to prevent.

This PR's own diff touches `.github/` and `lang/scripts/`, so it selects all 47 — visible in the `Enumerate languages` job log.

## Branch protection

The required `Test languages` check accepts a skipped matrix **only** when the selection was genuinely empty (`[]`). A matrix skipped for any other reason still fails the check, so it cannot silently pass.

## Tests

`lang/test_languages_for_paths.py` (6 cases) covers the cross-grammar edges, the no-language-of-its-own dirs, shared paths, mixed diffs, and the empty-diff fallback. Wired into `make test-python`.